### PR TITLE
added testing workflow

### DIFF
--- a/.github/workflows/ros1-navigation-test.yaml
+++ b/.github/workflows/ros1-navigation-test.yaml
@@ -1,0 +1,24 @@
+name: Test ROS1 Navigation
+
+on:
+  schedule:
+    - cron:  '0 18 * * 1'
+    
+jobs:
+  test-navigation:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ros1
+    
+    - name: Build and run tests
+      run: docker run --rm husarion/rosbot:melodic-simulation rostest navigation_testing navigation.test
+      
+
+    
+    


### PR DESCRIPTION
According to [this post](https://stackoverflow.com/questions/63436541/github-action-workflow-schedule-not-working-on-non-default-branch) scheduled workflows can only be run from default branch (master in our case)