### PR TITLE
Add ignition support

### DIFF
--- a/rosbot/package.xml
+++ b/rosbot/package.xml
@@ -20,6 +20,10 @@
   <depend>rosbot_description</depend>
   <depend>rosbot_controller</depend>
 
+  <depend condition="($HUSARION_ROS_BUILD_TYPE == simulation) and ($SIMULATION_ENGINE == ignition-gazebo)">
+    rosbot_gazebo
+  </depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rosbot/rosbot_simulation.repos
+++ b/rosbot/rosbot_simulation.repos
@@ -1,0 +1,12 @@
+repositories:
+  gazebosim/gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    # on branch humble hardware isn't activated
+    # recently on master API breaking change was introduced, it is necessay to use commit before this change
+    version: b296ff2f5c3758b637a70bd496fe6ed875ab03ce
+
+  husarion/gazebo_worlds:
+    type: git
+    url: https://github.com/husarion/gazebo_worlds.git
+    version: main

--- a/rosbot_bringup/launch/bringup.launch.py
+++ b/rosbot_bringup/launch/bringup.launch.py
@@ -1,13 +1,32 @@
 from launch import LaunchDescription
-from launch_ros.actions import Node
+from launch_ros.actions import Node, SetParameter
 from launch.substitutions import  PathJoinSubstitution
 from ament_index_python.packages import get_package_share_directory
-from launch.actions import IncludeLaunchDescription
+from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import (
+    LaunchConfiguration,
+    PathJoinSubstitution
+)
 
 
 def generate_launch_description():
+    use_sim = LaunchConfiguration("use_sim")
+    declare_use_sim_arg = DeclareLaunchArgument(
+        "use_sim",
+        default_value="False",
+        description="Whether simulation is used",
+    )
+
+    simulation_engine = LaunchConfiguration("simulation_engine")
+    declare_simulation_engine_arg = DeclareLaunchArgument(
+        "simulation_engine",
+        default_value="webots",
+        description="Which simulation engine to be used",
+        choices=["ignition-gazebo", "gazebo-classic", "webots"]
+    )
+
+
     rosbot_controller = get_package_share_directory("rosbot_controller")
     rosbot_bringup = get_package_share_directory("rosbot_bringup")
 
@@ -20,7 +39,11 @@ def generate_launch_description():
                     "controller.launch.py",
                 ]
             )
-        )
+        ),
+        launch_arguments={
+            "use_sim": use_sim,
+            "simulation_engine": simulation_engine,
+        }.items(),
     )
 
     ekf_config = PathJoinSubstitution([rosbot_bringup, "config", "ekf.yaml"])
@@ -34,6 +57,9 @@ def generate_launch_description():
     )
 
     actions = [
+        declare_use_sim_arg,
+        declare_simulation_engine_arg,
+        SetParameter(name="use_sim_time", value=use_sim),
         rosbot_controller_launch,
         robot_localization_node
     ]

--- a/rosbot_controller/config/rosbot_controllers.yaml
+++ b/rosbot_controller/config/rosbot_controllers.yaml
@@ -1,3 +1,22 @@
+simulation_ignition_ros_control:
+  ros__parameters:
+    use_sim_time: true
+
+# Separate controller manager used for simulation - only difference is 
+# the use_sim_time parameter (it is the easiest way to do it with ign ros2 control)  
+simulation_controller_manager:
+  ros__parameters:
+    use_sim_time: true
+    update_rate: 20 # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    rosbot_base_controller:
+      type: diff_drive_controller/DiffDriveController
+    imu_broadcaster:
+      type: imu_sensor_broadcaster/IMUSensorBroadcaster
+
+
 controller_manager:
   ros__parameters:
     update_rate: 20 # Hz

--- a/rosbot_description/urdf/body.urdf.xacro
+++ b/rosbot_description/urdf/body.urdf.xacro
@@ -31,7 +31,7 @@
 
       <inertial>
         <mass value="2.0" />
-        <inertia ixx="0.001" ixy="0.000" ixz="0.000" iyy="0.001" iyz="0.000" izz="0.001" />
+        <inertia ixx="0.00721" ixy="0" ixz="0" iyy="0.01035" iyz="0" izz="0.01006" />
       </inertial>
     </link>
     <gazebo reference="body_link">
@@ -57,11 +57,6 @@
       <gazebo reference="cover_link">
         <material>Gazebo/Red</material>
       </gazebo>
-
-      <inertial>
-        <mass value="0.000001" />
-        <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="0.0" />
-      </inertial>
     </link>
 
     <joint name="body_to_imu_joint" type="fixed">
@@ -70,12 +65,7 @@
       <child link="imu_link" />
     </joint>
 
-    <link name="imu_link">
-      <inertial>
-        <mass value="0.001" />
-        <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1" />
-      </inertial>
-    </link>
+    <link name="imu_link" />
 
     <joint name="body_to_camera_joint" type="fixed">
       <origin xyz="-0.0141 0.0 0.125" rpy="0.0 0.0 0.0" />
@@ -83,12 +73,7 @@
       <child link="camera_link" />
     </joint>
 
-    <link name="camera_link">
-      <inertial>
-        <mass value="0.000001" />
-        <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1" />
-      </inertial>
-    </link>
+    <link name="camera_link" />
 
     <joint name="fl_range_joint" type="fixed">
       <axis xyz="0 1 0" />
@@ -96,7 +81,8 @@
       <parent link="body_link" />
       <child link="fl_range" />
     </joint>
-    <link name="fl_range"></link>
+
+    <link name="fl_range" />
 
     <joint name="fr_range_joint" type="fixed">
       <axis xyz="0 1 0" />
@@ -104,7 +90,8 @@
       <parent link="body_link" />
       <child link="fr_range" />
     </joint>
-    <link name="fr_range"></link>
+
+    <link name="fr_range" />
 
     <joint name="rl_range_joint" type="fixed">
       <axis xyz="0 1 0" />
@@ -112,7 +99,8 @@
       <parent link="body_link" />
       <child link="rl_range" />
     </joint>
-    <link name="rl_range"></link>
+
+    <link name="rl_range" />
 
     <joint name="rr_range_joint" type="fixed">
       <axis xyz="0 1 0" />
@@ -120,7 +108,8 @@
       <parent link="body_link" />
       <child link="rr_range" />
     </joint>
-    <link name="rr_range"></link>
+    
+    <link name="rr_range" />
 
   </xacro:macro>
 </robot>

--- a/rosbot_description/urdf/rosbot_macro.urdf.xacro
+++ b/rosbot_description/urdf/rosbot_macro.urdf.xacro
@@ -57,6 +57,9 @@
         </xacro:unless>
 
         <xacro:if value="$(arg use_sim)">
+          <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+            <plugin>ign_ros2_control/IgnitionSystem</plugin>
+          </xacro:if>
           <xacro:if value="${simulation_engine == 'webots'}">
             <plugin>webots_ros2_control::Ros2ControlSystem</plugin>
           </xacro:if>
@@ -83,10 +86,51 @@
         <state_interface name="position" />
         <state_interface name="velocity" />
       </joint>
+    
+      <xacro:if value="${use_sim}">
+        <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+          <sensor name="imu">
+            <state_interface name="orientation.x" />
+            <state_interface name="orientation.y" />
+            <state_interface name="orientation.z" />
+            <state_interface name="orientation.w" />
+            <state_interface name="angular_velocity.x" />
+            <state_interface name="angular_velocity.y" />
+            <state_interface name="angular_velocity.z" />
+            <state_interface name="linear_acceleration.x" />
+            <state_interface name="linear_acceleration.y" />
+            <state_interface name="linear_acceleration.z" />
+          </sensor>
+        </xacro:if>
+      </xacro:if>
     </ros2_control>
 
     <!-- GAZEBO PLUGINS DECLARATION -->
     <xacro:if value="${use_sim}">
+      <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+        <gazebo>
+          <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+            <parameters>$(find rosbot_controller)/config/rosbot_controllers.yaml</parameters>
+            <controller_manager_prefix_node_name>simulation</controller_manager_prefix_node_name>
+            <ros>
+              <remapping>/rosbot_base_controller/cmd_vel_unstamped:=/cmd_vel</remapping>
+            </ros>
+          </plugin>
+        </gazebo>
+        <gazebo reference="imu_link">
+          <sensor name="imu" type="imu">
+            <plugin filename="ignition-gazebo-imu-system" name="ignition::gazebo::systems::Imu"></plugin>
+            <always_on>true</always_on>
+            <update_rate>25</update_rate>
+            <topic>imu/data_raw</topic>
+            <visualize>false</visualize>
+            <enable_metrics>false</enable_metrics>
+            <frame_id>imu_link</frame_id>
+            <ignition_frame_id>imu_link</ignition_frame_id>
+          </sensor>
+        </gazebo>
+      </xacro:if>
+
       <xacro:if value="${simulation_engine == 'gazebo-classic'}">
         <!-- Control robot wheels -->
         <gazebo>

--- a/rosbot_description/urdf/wheel.urdf.xacro
+++ b/rosbot_description/urdf/wheel.urdf.xacro
@@ -61,7 +61,9 @@
 
       <inertial>
         <mass value="0.100" />
-        <inertia ixx="0.00007" ixy="0" ixz="0" iyy="0.0001263" iyz="0" izz="0.00007" />
+        <inertia ixx="0.00007" ixy="0.0"       ixz="0.0"
+                               iyy="0.0001263" iyz="0.0"
+                                               izz="0.00007" />
       </inertial>
     </link>
 

--- a/rosbot_description/urdf/wheel.urdf.xacro
+++ b/rosbot_description/urdf/wheel.urdf.xacro
@@ -61,9 +61,7 @@
 
       <inertial>
         <mass value="0.100" />
-        <inertia ixx="0.001" ixy="0.000" ixz="0.000"
-                             iyy="0.001" iyz="0.000"
-                                         izz="0.001" />
+        <inertia ixx="0.00007" ixy="0" ixz="0" iyy="0.0001263" iyz="0" izz="0.00007" />
       </inertial>
     </link>
 

--- a/rosbot_gazebo/CMakeLists.txt
+++ b/rosbot_gazebo/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.10.2)
+project(rosbot_gazebo)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/rosbot_gazebo/launch/simulation.launch.py
+++ b/rosbot_gazebo/launch/simulation.launch.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+from launch import LaunchDescription
+from launch.actions import (
+    IncludeLaunchDescription,
+    DeclareLaunchArgument,
+)
+from launch.substitutions import (
+    PathJoinSubstitution,
+    LaunchConfiguration,
+)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+from launch_ros.actions import Node, SetParameter
+
+from ament_index_python.packages import get_package_share_directory
+
+
+def generate_launch_description():
+
+    map_package = get_package_share_directory("husarion_office_gz")
+    world_file = PathJoinSubstitution([map_package, "worlds", "husarion_world.sdf"])
+    world_cfg = LaunchConfiguration("world")
+    declare_world_arg = DeclareLaunchArgument(
+        "world", default_value=["-r ", world_file], description="SDF world file"
+    )
+
+    gz_sim = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    get_package_share_directory("ros_gz_sim"),
+                    "launch",
+                    "gz_sim.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={"gz_args": world_cfg}.items(),
+    )
+
+    gz_spawn_entity = Node(
+        package="ros_gz_sim",
+        executable="create",
+        arguments=[
+            "-name",
+            "rosbot",
+            "-allow_renaming",
+            "true",
+            "-topic",
+            "robot_description",
+            "-x",
+            "0",
+            "-y",
+            "2.0",
+            "-z",
+            "0.2",
+        ],
+        output="screen",
+    )
+    ign_bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        name="ros_gz_bridge",
+        arguments=[
+            "/scan" + "@sensor_msgs/msg/LaserScan" + "[ignition.msgs.LaserScan",
+            "/camera/camera_info" + "@sensor_msgs/msg/CameraInfo" + "[ignition.msgs.CameraInfo",
+            "/camera/depth_image" + "@sensor_msgs/msg/Image" + "[ignition.msgs.Image",
+            "/camera/image" + "@sensor_msgs/msg/Image" + "[ignition.msgs.Image",
+            "/camera/points" + "@sensor_msgs/msg/PointCloud2" + "[ignition.msgs.PointCloudPacked",
+            "/clock" + "@rosgraph_msgs/msg/Clock" + "[ignition.msgs.Clock",
+        ],
+        output="screen",
+    )
+
+    bringup_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    get_package_share_directory("rosbot_bringup"),
+                    "launch",
+                    "bringup.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={
+            "use_sim": "True",
+            "simulation_engine": "ignition-gazebo"
+        }.items(),
+    )
+
+    return LaunchDescription(
+        [
+            declare_world_arg,
+            # Sets use_sim_time for all nodes started below (doesn't work for nodes started from ignition gazebo)
+            SetParameter(name="use_sim_time", value=True),
+            gz_sim,
+            ign_bridge,
+            gz_spawn_entity,
+            bringup_launch,
+        ]
+    )
+
+
+if __name__ == "__main__":
+    generate_launch_description()

--- a/rosbot_gazebo/launch/simulation.launch.py
+++ b/rosbot_gazebo/launch/simulation.launch.py
@@ -99,7 +99,3 @@ def generate_launch_description():
             bringup_launch,
         ]
     )
-
-
-if __name__ == "__main__":
-    generate_launch_description()

--- a/rosbot_gazebo/package.xml
+++ b/rosbot_gazebo/package.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosbot_gazebo</name>
+  <version>0.4.0</version>
+
+  <description>The rosbot_gazebo package</description>
+  <license>Apache License 2.0</license>
+
+  <author email="krzysztof.wojciechowski@husarion.com">Krzysztof Wojciechowski</author>
+  <maintainer email="support@husarion.com">Husarion</maintainer>
+
+  <url type="website">https://husarion.com/</url>
+  <url type="repository">https://github.com/husarion/rosbot_ros</url>
+  <url type="bugtracker">https://github.com/husarion/rosbot_ros/issues</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>rosbot_bringup</exec_depend>
+
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+
+  <exec_depend>husarion_office_gz</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
+  <!-- Ignition dependency is specified in the ros_gz_sim package,
+    version can chosen using GZ_VERSION (or IGNITION_VERSION) env variable,
+    for details refer to the ros_gz_sim package -->
+  <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>ign_ros2_control</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
bump::minor

I had troubles working with Webots, so I decided to port Rosbot XL Ignition setup to Rosbot 2R. At least the basic configuration. There is related [PR#21](https://github.com/husarion/ros_components_description/pull/21) fixing LiDARs and adding a camera. The camera does not work yet due to issues with the ign plugin. Nevertheless, the current setup is enough to run mapping demos. I also partially fixed inertial (it still has to be set to proper values later on) to make sure the whole robot will behave well in simulation.