### PR TITLE
Rename gazebo_worlds to husarion_office_gz

### DIFF
--- a/rosbot/rosbot_simulation.repos
+++ b/rosbot/rosbot_simulation.repos
@@ -6,7 +6,7 @@ repositories:
     # recently on master API breaking change was introduced, it is necessay to use commit before this change
     version: b296ff2f5c3758b637a70bd496fe6ed875ab03ce
 
-  husarion/gazebo_worlds:
+  husarion/husarion_office_gz:
     type: git
-    url: https://github.com/husarion/gazebo_worlds.git
+    url: https://github.com/husarion/husarion_office_gz
     version: main


### PR DESCRIPTION
bump::patch

The gazebo_wolds repo was renamed in https://github.com/husarion/husarion_office_gz/pull/3 and this is meant to reflect changes here as well