### PR TITLE
[Backport humble] Set default ROSbot 3 lidar to S2

### DIFF
--- a/rosbot_description/config/rosbot/basic.yaml
+++ b/rosbot_description/config/rosbot/basic.yaml
@@ -1,6 +1,6 @@
 ---
 components:
-  - type: LDR01
+  - type: LDR02
     parent_link: cover_link
     xyz: 0.02 0.0 0.0
     rpy: 0.0 0.0 0.0


### PR DESCRIPTION
# Description
Backport of #140 to `humble`.