### PR TITLE
Backport #149: Add config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,8 @@ ros2 launch rosbot_gazebo simulation.launch.py robot_model:=<rosbot/rosbot_xl>
 
 | 🤖  | 🖥️  | Argument            | Description <br/> **_Type:_** `Default`                                                                                                                                                            |
 | --- | --- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅  | ✅  | `components_config` | Specify file which contains components. These components will be included in URDF. Available options can be found in [husarion_components_description](https://github.com/husarion/husarion_components_description/blob/ros2/README.md#available-urdf-sensors) <br/> **_string_:** [`components.yaml`](rosbot_description/config/components.yaml)                                                                                       |
-| ✅  | ✅  | `configuration` | Specify configuration packages. Currently only ROSbot XL has available packages. Packages: `basic`, `telepresence`, `autonomy`, `manipulation`, `manipulation_pro`. <br/> **_string:_** 'basic'                                                                          |
-| ✅  | ✅  | `controller_config` | Path to controller configuration file. <br/> **_string:_** [`{robot_model}/{mecanum/diff}_drive_controller.yaml`](rosbot_controller/config/)                                                                                       |
-| ✅  | ✅  | `joy_config`       | The file path to the configuration YAML file for the `teleop_twist_joy` node. <br/> **_string:_** [`joy.yaml`](rosbot_bringup/config/joy.yaml) |
+| ✅  | ✅  | `config_dir`    | Path to the common configuration directory. You can create such common configuration directory with `ros2 run rosbot_utils create_config_dir {directory}`. <br/> **_string:_** `""`                                                                          |
+| ✅  | ✅  | `configuration` | Specify configuration packages. Currently only ROSbot XL has available packages. Packages: `basic`, `telepresence`, `autonomy`, `manipulation`, `manipulation_pro`, `custom`. <br/> **_string:_** 'basic'                                                                          |
 | ✅  | ✅  | `joy_vel`       | The topic name to which velocity commands will be published. <br/> **_string:_** `cmd_vel` |
 | ✅  | ✅  | `mecanum`           | Whether to use mecanum drive controller, otherwise use diff drive. <br/> **_bool:_** `False`                                                                                       |
 | ✅  | ✅  | `namespace`         | Add namespace to all launched nodes. <br/> **_string:_** `env(ROBOT_NAMESPACE)`                                                                                                                       |
@@ -111,7 +109,6 @@ ros2 launch rosbot_gazebo simulation.launch.py robot_model:=<rosbot/rosbot_xl>
 | ✅  | ❌  | `port`              | **ROSbot XL only.** UDP4 port for micro-ROS agent. <br/> **_string:_** `8888`                                                                                                                         |
 | ✅  | ❌  | `serial_baudrate`   | ROSbot only. Baud rate for serial communication. <br/> **_string:_** `576000`                                                                                                                                  |
 | ✅  | ❌  | `serial_port`       | ROSbot only. Serial port for micro-ROS agent. <br/> **_string:_** `/dev/ttySERIAL`                                                                                                           |
-| ✅  | ❌  | `fastrtps_profiles` | Path to the Fast RTPS default profiles file for Micro-ROS agent for localhost only setup. <br/> **_string:_** [`microros_localhost_only.xml`](./rosbot_bringup/config/microros_localhost_only.xml) |
 | ❌  | ✅  | `gz_gui`            | Run simulation with specific GUI layout. <br/> **_string:_** [`teleop.config`](https://github.com/husarion/husarion_gz_worlds/blob/main/config/teleop.config)                                      |
 | ❌  | ✅  | `gz_headless_mode`  | Run the simulation in headless mode. Useful when a GUI is not needed or to reduce the number of calculations. <br/> **_bool:_** `False`                                                            |
 | ❌  | ✅  | `gz_log_level`      | Adjust the level of console output. <br/> **_int:_** `1` (choices: `0`, `1`, `2`, `3`, `4`)                                                                                                        |
@@ -125,8 +122,7 @@ ros2 launch rosbot_gazebo simulation.launch.py robot_model:=<rosbot/rosbot_xl>
 | ❌  | ✅  | `yaw`               | Initial robot 'yaw' orientation. <br/> **_float:_** `0.0`                                                                                                                                          |
 
 > [!TIP]
->
-> To read the arguments for individual packages, add the `-s` flag to the `ros2 launch` command (e.g. `ros2 launch rosbot_bringup bringup.launch.py ​​-s`)
+> To read the arguments for individual launch files, add the `-s` flag to the `ros2 launch` command (e.g. `ros2 launch rosbot_bringup bringup.launch.py ​​-s`)
 
 ## 🕹️ Demo
 

--- a/rosbot_bringup/launch/microros.launch.py
+++ b/rosbot_bringup/launch/microros.launch.py
@@ -25,6 +25,7 @@ from launch.substitutions import (
     EnvironmentVariable,
     LaunchConfiguration,
     PathJoinSubstitution,
+    PythonExpression,
 )
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -39,11 +40,26 @@ def generate_microros_agent_node(context, *args, **kwargs):
             SetEnvironmentVariable(name="XRCE_DOMAIN_ID_OVERRIDE", value=ros_domain_id)
         )
 
-    fastrtps_profiles = LaunchConfiguration("fastrtps_profiles").perform(context)
+    config_dir = LaunchConfiguration("config_dir").perform(context)
     port = LaunchConfiguration("port").perform(context)
     robot_model = LaunchConfiguration("robot_model").perform(context)
     serial_baudrate = LaunchConfiguration("serial_baudrate").perform(context)
     serial_port = LaunchConfiguration("serial_port").perform(context)
+
+    config_rosbot_bringup_dir = PythonExpression(
+        [
+            "'",
+            config_dir,
+            "/rosbot_bringup' if '",
+            config_dir,
+            "' else '",
+            FindPackageShare("rosbot_bringup"),
+            "'",
+        ]
+    )
+    fastrtps_profiles = PathJoinSubstitution(
+        [config_rosbot_bringup_dir, "config", "microros_localhost_only.xml"]
+    )
 
     micoros_communication_args = {
         "rosbot": ["serial", "-b", serial_baudrate, "-D", serial_port],
@@ -78,15 +94,10 @@ def generate_microros_agent_node(context, *args, **kwargs):
 
 
 def generate_launch_description():
-    default_fastrtps_profiles = PathJoinSubstitution(
-        [FindPackageShare("rosbot_bringup"), "config", "microros_localhost_only.xml"]
-    )
-    declare_fastrtps_profiles_arg = DeclareLaunchArgument(
-        "fastrtps_profiles",
-        default_value=default_fastrtps_profiles,
-        description=(
-            "Path to the Fast RTPS default profiles file for Micro-ROS agent for localhost only setup"
-        ),
+    declare_config_dir_arg = DeclareLaunchArgument(
+        "config_dir",
+        default_value="",
+        description="Path to the common configuration directory. You can create such common configuration directory with `ros2 run rosbot_utils create_config_dir {directory}`.",
     )
 
     declare_port_arg = DeclareLaunchArgument(
@@ -116,7 +127,7 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
-            declare_fastrtps_profiles_arg,
+            declare_config_dir_arg,
             declare_port_arg,
             declare_robot_model_arg,
             declare_serial_baudrate_arg,

--- a/rosbot_controller/launch/controller.launch.py
+++ b/rosbot_controller/launch/controller.launch.py
@@ -40,14 +40,25 @@ from rosbot_utils.utils import find_device_port
 
 
 def generate_launch_description():
+    config_dir = LaunchConfiguration("config_dir")
     configuration = LaunchConfiguration("configuration")
-    controller_config = LaunchConfiguration("controller_config")
     manipulator_serial_port = LaunchConfiguration("manipulator_serial_port")
     mecanum = LaunchConfiguration("mecanum")
     namespace = LaunchConfiguration("namespace")
     robot_model = LaunchConfiguration("robot_model")
     use_sim = LaunchConfiguration("use_sim", default="False")
 
+    config_search_path = PythonExpression(
+        [
+            "'",
+            config_dir,
+            "/rosbot_controller' if '",
+            config_dir,
+            "' else '",
+            FindPackageShare("rosbot_controller"),
+            "'",
+        ]
+    )
     base_controller_prefix = PythonExpression(
         ["'mecanum_drive' if ", mecanum, " else 'diff_drive'"]
     )
@@ -56,14 +67,14 @@ def generate_launch_description():
     controller_config_file = PythonExpression(
         ["'", base_controller_prefix, "' + '_' + '", manipulator_prefix, "' + 'controller.yaml'"]
     )
-    default_controller_config = PathJoinSubstitution(
-        [FindPackageShare("rosbot_controller"), "config", robot_model, controller_config_file]
+    controller_config = PathJoinSubstitution(
+        [config_search_path, "config", robot_model, controller_config_file]
     )
 
-    declare_controller_config_arg = DeclareLaunchArgument(
-        "controller_config",
-        default_value=default_controller_config,
-        description="Path to controller configuration file.",
+    declare_config_dir_arg = DeclareLaunchArgument(
+        "config_dir",
+        default_value="",
+        description="Path to the common configuration directory. You can create such common configuration directory with `ros2 run rosbot_utils create_config_dir {directory}`.",
     )
 
     declare_configuration_arg = DeclareLaunchArgument(
@@ -72,7 +83,14 @@ def generate_launch_description():
         description=(
             "Specify configuration packages. Currently only ROSbot XL has available packages."
         ),
-        choices=["basic", "telepresence", "autonomy", "manipulation", "manipulation_pro"],
+        choices=[
+            "basic",
+            "telepresence",
+            "autonomy",
+            "manipulation",
+            "manipulation_pro",
+            "custom",
+        ],
     )
 
     default_manipulator_serial_port = find_device_port("0403", "6014", "/dev/ttyUSB0")
@@ -215,11 +233,11 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            declare_config_dir_arg,
             declare_configuration_arg,
             declare_manipulator_serial_port_arg,
             declare_robot_model_arg,
             declare_mecanum_arg,  # mecanum base on robot_model arg
-            declare_controller_config_arg,  # controler_config base on mecanum and robot_model arg
             load_urdf,
             control_node,
             delayed_controllers,

--- a/rosbot_description/config/rosbot/custom.yaml
+++ b/rosbot_description/config/rosbot/custom.yaml
@@ -1,0 +1,2 @@
+---
+components: []

--- a/rosbot_description/config/rosbot_xl/custom.yaml
+++ b/rosbot_description/config/rosbot_xl/custom.yaml
@@ -1,0 +1,2 @@
+---
+components: []

--- a/rosbot_description/launch/load_urdf.launch.py
+++ b/rosbot_description/launch/load_urdf.launch.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import yaml
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.conditions import IfCondition
@@ -39,7 +42,7 @@ def contains_cam_component(yaml_fil):
 
 
 def launch_setup(context, *args, **kwargs):
-    components_config = LaunchConfiguration("components_config").perform(context)
+    config_dir = LaunchConfiguration("config_dir").perform(context)
     configuration = LaunchConfiguration("configuration").perform(context)
     controller_config = LaunchConfiguration("controller_config", default="").perform(context)
     manipulator_serial_port = LaunchConfiguration(
@@ -51,7 +54,17 @@ def launch_setup(context, *args, **kwargs):
     robot_model = LaunchConfiguration("robot_model").perform(context)
     use_sim = LaunchConfiguration("use_sim", default="False").perform(context)
 
-    if robot_model != "rosbot_xl" and configuration != "basic":
+    config_rosbot_description_dir = (
+        config_dir + "/rosbot_description"
+        if config_dir
+        else get_package_share_directory("rosbot_description")
+    )
+    components_file = f"{configuration}.yaml"
+    components_config = os.path.join(
+        config_rosbot_description_dir, "config", robot_model, components_file
+    )
+
+    if robot_model != "rosbot_xl" and configuration not in ("basic", "custom"):
         raise ValueError(
             "Invalid configuration and robot model combination. Only 'rosbot_xl' has configuration options."
         )
@@ -112,19 +125,12 @@ def launch_setup(context, *args, **kwargs):
 
 
 def generate_launch_description():
-    configuration = LaunchConfiguration("configuration")
     robot_model = LaunchConfiguration("robot_model")
-    components_file = PythonExpression(["'", configuration, "' + '.yaml'"])
-    default_components_config = PathJoinSubstitution(
-        [FindPackageShare("rosbot_description"), "config", robot_model, components_file]
-    )
-    declare_components_config_arg = DeclareLaunchArgument(
-        "components_config",
-        default_value=default_components_config,
-        description=(
-            "Specify file which contains components. These components will be included in URDF. "
-            "Available options can be found in [husarion_components_description](https://github.com/husarion/husarion_components_description/blob/jazzy/README.md#available-urdf-sensors)"
-        ),
+
+    declare_config_dir_arg = DeclareLaunchArgument(
+        "config_dir",
+        default_value="",
+        description="Path to the common configuration directory. You can create such common configuration directory with `ros2 run rosbot_utils create_config_dir {directory}`.",
     )
 
     declare_configuration_arg = DeclareLaunchArgument(
@@ -133,7 +139,14 @@ def generate_launch_description():
         description=(
             "Specify configuration packages. Currently only ROSbot XL has available packages"
         ),
-        choices=["basic", "telepresence", "autonomy", "manipulation", "manipulation_pro"],
+        choices=[
+            "basic",
+            "telepresence",
+            "autonomy",
+            "manipulation",
+            "manipulation_pro",
+            "custom",
+        ],
     )
 
     default_mecanum_value = PythonExpression(["'", robot_model, "' == 'rosbot_xl'"])
@@ -155,9 +168,9 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            declare_config_dir_arg,
             declare_configuration_arg,
             declare_robot_model_arg,
-            declare_components_config_arg,  # depends on configuration and robot model
             declare_mecanum_arg,  # mecanum base on robot_model arg
             publish_robot_description,
         ]

--- a/rosbot_gazebo/launch/simulation.launch.py
+++ b/rosbot_gazebo/launch/simulation.launch.py
@@ -16,13 +16,25 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import (
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    PythonExpression,
+)
 from launch_ros.actions import Node, SetParameter, SetRemap
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    config_dir = LaunchConfiguration("config_dir")
     rviz = LaunchConfiguration("rviz")
+
+    declare_config_dir_arg = DeclareLaunchArgument(
+        "config_dir",
+        default_value="",
+        description="Path to the common configuration directory. You can create such common configuration directory with `ros2 run rosbot_utils create_config_dir {directory}`.",
+    )
+
     declare_rviz_arg = DeclareLaunchArgument(
         "rviz",
         default_value="True",
@@ -39,9 +51,19 @@ def generate_launch_description():
         launch_arguments={"gz_log_level": "1"}.items(),
     )
 
-    gz_bridge_config = PathJoinSubstitution(
-        [FindPackageShare("rosbot_gazebo"), "config", "gz_bridge.yaml"]
+    config_rosbot_gazebo_dir = PythonExpression(
+        [
+            "'",
+            config_dir,
+            "/rosbot_gazebo' if '",
+            config_dir,
+            "' else '",
+            FindPackageShare("rosbot_gazebo"),
+            "'",
+        ]
     )
+
+    gz_bridge_config = PathJoinSubstitution([config_rosbot_gazebo_dir, "config", "gz_bridge.yaml"])
     gz_bridge = Node(
         package="ros_gz_bridge",
         executable="parameter_bridge",
@@ -77,6 +99,7 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            declare_config_dir_arg,
             declare_rviz_arg,
             SetRemap("/diagnostics", "diagnostics"),
             SetRemap("/tf", "tf"),

--- a/rosbot_gazebo/launch/spawn_robot.launch.py
+++ b/rosbot_gazebo/launch/spawn_robot.launch.py
@@ -27,7 +27,7 @@ from nav2_common.launch import ReplaceString
 
 
 def generate_launch_description():
-    components_config = LaunchConfiguration("components_config")
+    config_dir = LaunchConfiguration("config_dir")
     configuration = LaunchConfiguration("configuration")
     namespace = LaunchConfiguration("namespace")
     robot_model = LaunchConfiguration("robot_model")
@@ -38,17 +38,33 @@ def generate_launch_description():
     pitch = LaunchConfiguration("pitch")
     yaw = LaunchConfiguration("yaw")
 
-    components_file = PythonExpression(["'", configuration, "' + '.yaml'"])
-    default_components_config = PathJoinSubstitution(
-        [FindPackageShare("rosbot_description"), "config", robot_model, components_file]
+    config_rosbot_description_dir = PythonExpression(
+        [
+            "'",
+            config_dir,
+            "/rosbot_description' if '",
+            config_dir,
+            "' else '",
+            FindPackageShare("rosbot_description"),
+            "'",
+        ]
     )
-    declare_components_config_arg = DeclareLaunchArgument(
-        "components_config",
-        default_value=default_components_config,
-        description=(
-            "Specify file which contains components. These components will be included in URDF. "
-            "Available options can be found in [husarion_components_description](https://github.com/husarion/husarion_components_description/blob/ros2/README.md#available-urdf-sensors)"
-        ),
+    config_rosbot_gazebo_dir = PythonExpression(
+        [
+            "'",
+            config_dir,
+            "/rosbot_gazebo' if '",
+            config_dir,
+            "' else '",
+            FindPackageShare("rosbot_gazebo"),
+            "'",
+        ]
+    )
+
+    declare_config_dir_arg = DeclareLaunchArgument(
+        "config_dir",
+        default_value="",
+        description="Path to the common configuration directory. You can create such common configuration directory with `ros2 run rosbot_utils create_config_dir {directory}`.",
     )
 
     declare_configuration_arg = DeclareLaunchArgument(
@@ -57,7 +73,14 @@ def generate_launch_description():
         description=(
             "Specify configuration packages. Currently only ROSbot XL has available packages"
         ),
-        choices=["basic", "telepresence", "autonomy", "manipulation", "manipulation_pro"],
+        choices=[
+            "basic",
+            "telepresence",
+            "autonomy",
+            "manipulation",
+            "manipulation_pro",
+            "custom",
+        ],
     )
 
     declare_namespace_arg = DeclareLaunchArgument(
@@ -148,15 +171,19 @@ def generate_launch_description():
     )
 
     gz_bridge_path = PathJoinSubstitution(
-        [FindPackageShare("rosbot_gazebo"), "config", "rosbot_bridge.yaml"]
+        [config_rosbot_gazebo_dir, "config", "rosbot_bridge.yaml"]
     )
     gz_bridge_config = ReplaceString(gz_bridge_path, {"<namespace>/": ns})
-
     gz_bridge = Node(
         package="ros_gz_bridge",
         executable="parameter_bridge",
         name="rosbot_gz_bridge",
         parameters=[{"config_file": gz_bridge_config}],
+    )
+
+    components_file = PythonExpression(["'", configuration, "' + '.yaml'"])
+    components_config = PathJoinSubstitution(
+        [config_rosbot_description_dir, "config", robot_model, components_file]
     )
 
     controller_launch = IncludeLaunchDescription(
@@ -170,7 +197,6 @@ def generate_launch_description():
             )
         ),
         launch_arguments={
-            "components_config": components_config,
             "configuration": configuration,
             "robot_model": robot_model,
             "use_sim": "True",
@@ -207,10 +233,10 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            declare_config_dir_arg,
             declare_configuration_arg,
             declare_namespace_arg,
             declare_robot_model_arg,
-            declare_components_config_arg,  # depends on configuration and robot model
             declare_x_arg,
             declare_y_arg,
             declare_z_arg,

--- a/rosbot_joy/launch/joy.launch.py
+++ b/rosbot_joy/launch/joy.launch.py
@@ -14,22 +14,38 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import (
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    PythonExpression,
+)
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    joy_config = LaunchConfiguration("joy_config")
+    config_dir = LaunchConfiguration("config_dir")
     joy_vel = LaunchConfiguration("joy_vel")
 
-    rosbot_joy = FindPackageShare("rosbot_joy")
-
-    declare_joy_config_arg = DeclareLaunchArgument(
-        "joy_config",
-        default_value=PathJoinSubstitution([rosbot_joy, "config", "joy.yaml"]),
-        description="The file path to the configuration YAML file for the teleop_twist_joy node.",
+    declare_config_dir_arg = DeclareLaunchArgument(
+        "config_dir",
+        default_value="",
+        description="Path to the common configuration directory. You can create such common configuration directory with `ros2 run rosbot_utils create_config_dir {directory}`.",
     )
+
+    config_rosbot_joy_dir = PythonExpression(
+        [
+            "'",
+            config_dir,
+            "/rosbot_joy' if '",
+            config_dir,
+            "' else '",
+            FindPackageShare("rosbot_joy"),
+            "'",
+        ]
+    )
+
+    joy_config = PathJoinSubstitution([config_rosbot_joy_dir, "config", "joy.yaml"])
 
     declare_joy_vel_arg = DeclareLaunchArgument(
         "joy_vel",
@@ -54,7 +70,7 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
-            declare_joy_config_arg,
+            declare_config_dir_arg,
             declare_joy_vel_arg,
             joy_node,
             joy2twist_node,

--- a/rosbot_localization/launch/ekf.launch.py
+++ b/rosbot_localization/launch/ekf.launch.py
@@ -15,15 +15,37 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.substitutions import PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import (
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    PythonExpression,
+)
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    config_dir = LaunchConfiguration("config_dir")
 
-    rosbot_localization = FindPackageShare("rosbot_localization")
-    ekf_config = PathJoinSubstitution([rosbot_localization, "config", "ekf.yaml"])
+    declare_config_dir_arg = DeclareLaunchArgument(
+        "config_dir",
+        default_value="",
+        description="Path to the common configuration directory. You can create such common configuration directory with `ros2 run rosbot_utils create_config_dir {directory}`.",
+    )
+
+    config_rosbot_localization_dirs = PythonExpression(
+        [
+            "'",
+            config_dir,
+            "/rosbot_localization' if '",
+            config_dir,
+            "' else '",
+            FindPackageShare("rosbot_localization"),
+            "'",
+        ]
+    )
+    ekf_config = PathJoinSubstitution([config_rosbot_localization_dirs, "config", "ekf.yaml"])
 
     robot_localization_node = Node(
         package="robot_localization",
@@ -33,4 +55,4 @@ def generate_launch_description():
         remappings=[("/diagnostics", "diagnostics")],
     )
 
-    return LaunchDescription([robot_localization_node])
+    return LaunchDescription([declare_config_dir_arg, robot_localization_node])

--- a/rosbot_utils/launch/laser_filter.launch.py
+++ b/rosbot_utils/launch/laser_filter.launch.py
@@ -20,13 +20,21 @@ from launch.substitutions import (
     EnvironmentVariable,
     LaunchConfiguration,
     PathJoinSubstitution,
+    PythonExpression,
 )
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    config_dir = LaunchConfiguration("config_dir")
     robot_model = LaunchConfiguration("robot_model")
+
+    declare_config_dir_arg = DeclareLaunchArgument(
+        "config_dir",
+        default_value="",
+        description="Path to the common configuration directory. You can create such common configuration directory with `ros2 run rosbot_utils create_config_dir {directory}`.",
+    )
 
     declare_robot_model_arg = DeclareLaunchArgument(
         "robot_model",
@@ -35,10 +43,20 @@ def generate_launch_description():
         choices=["rosbot", "rosbot_xl"],
     )
 
-    rosbot_utils = FindPackageShare("rosbot_utils")
+    config_rosbot_utils_dir = PythonExpression(
+        [
+            "'",
+            config_dir,
+            "/rosbot_utils' if '",
+            config_dir,
+            "' else '",
+            FindPackageShare("rosbot_utils"),
+            "'",
+        ]
+    )
 
     laser_filter_config = PathJoinSubstitution(
-        [rosbot_utils, "config", robot_model, "laser_filter.yaml"]
+        [config_rosbot_utils_dir, "config", robot_model, "laser_filter.yaml"]
     )
 
     laser_filter_node = Node(
@@ -48,4 +66,10 @@ def generate_launch_description():
         parameters=[laser_filter_config],
     )
 
-    return LaunchDescription([declare_robot_model_arg, laser_filter_node])
+    return LaunchDescription(
+        [
+            declare_config_dir_arg,
+            declare_robot_model_arg,
+            laser_filter_node,
+        ]
+    )

--- a/rosbot_utils/rosbot_utils/create_config_dir.py
+++ b/rosbot_utils/rosbot_utils/create_config_dir.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Husarion sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import shutil
+
+from ament_index_python.packages import get_package_share_directory
+
+
+def copy_config_folder(pkg_name, dest_dir):
+    """
+    Copy the entire <pkg_share>/config directory.
+
+    This includes all files and subfolders into `dest_dir`.
+    Prompts the user if the destination already exists.
+    """
+    try:
+        pkg_share = get_package_share_directory(pkg_name)
+    except Exception:
+        print(
+            f"Package '{pkg_name}' not found."
+        )  # Hardware/Simulation specific package difference
+        return
+    src_config_dir = os.path.join(pkg_share, "config")
+    dest_config_dir = os.path.join(dest_dir, pkg_name, "config")
+
+    if not os.path.exists(src_config_dir):
+        print(f"[WARNING] Package '{pkg_name}' has no 'config' directory at {src_config_dir}")
+        return
+
+    # Copy the entire config folder (files + directories)
+    shutil.copytree(src_config_dir, dest_config_dir)
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(
+        description="Copy full 'config' folders from multiple ROS 2 packages."
+    )
+    parser.add_argument(
+        "destination", help="Destination base directory to copy config folders into"
+    )
+    args = parser.parse_args()
+
+    packages_list = [
+        "rosbot_bringup",
+        "rosbot_controller",
+        "rosbot_description",
+        "rosbot_gazebo",
+        "rosbot_joy",
+        "rosbot_localization",
+        "rosbot_utils",
+    ]
+
+    # Ask if destination exists
+    if os.path.exists(args.destination):
+        response = (
+            input(f"[?] Destination '{args.destination}' exists. Overwrite? [y/N]: ")
+            .strip()
+            .lower()
+        )
+        if response != "y":
+            print("Aborted.")
+            exit()
+        shutil.rmtree(args.destination)
+
+    for pkg in packages_list:
+        copy_config_folder(pkg, args.destination)
+
+    print(f"✅ All Config folders copied to '{args.destination}'\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/rosbot_utils/setup.py
+++ b/rosbot_utils/setup.py
@@ -47,6 +47,9 @@ setup(
     license="Apache License 2.0",
     tests_require=["pytest"],
     entry_points={
-        "console_scripts": ["flash_firmware = rosbot_utils.flash_firmware:main"],
+        "console_scripts": [
+            "flash_firmware = rosbot_utils.flash_firmware:main",
+            "create_config_dir = rosbot_utils.create_config_dir:main",
+        ],
     },
 )


### PR DESCRIPTION
bump::minor
- Logic for loading parameters from a different path, containing the same configuration file structure as the rosbot_ros repository. This is a useful feature for editing parameters from within a snap.
- A script `create_config_dir.py` for creating a configuration folder has also been added.