### PR TITLE
Deduplicate FIRMWARE_VERSION across rosbot_utils

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,7 @@ A "new feature" entry template in **CLAUDE.md** (section [9](#9-decision-and-nua
 - *2025-04-XX: Firmware bumped to `v1.1.0-jazzy`, improved PID (commits `b87b1a4`, `e5509b2`).*
 - *2026-05-04: Exposed `frame_filters` parameter for `tf_namespace_bridge` via per-package config files in `rosbot_bringup/config/` and `rosbot_gazebo/config/` (default empty = pass-through).*
 - *2026-05-15: Namespaced MoveIt topics for `joy2servo` and `servo_node`. `MoveGroupInterface` builds its `trajectory_execution_event` / `attached_collision_object` publishers via `rclcpp::names::append(opt.move_group_namespace, TOPIC)` — that is an FQN expansion that **ignores** the parent node's namespace, so the 2-arg ctor leaves these topics at `/`. Fixed by passing `this->get_namespace()` as the 3rd arg of `MoveGroupInterface::Options`. `moveit_servo`'s `monitored_planning_scene_topic` defaults to absolute `/planning_scene` (leading slash strips namespace from the PSM's private node) — fixed by setting it to relative `planning_scene` in `rosbot_moveit/config/moveit_servo.yaml`. `/parameter_events` is global by design.*
+- *2026-05-18: Deduplicated FIRMWARE_VERSION constant — single source in `rosbot_utils.firmware_version`.*
 
 ---
 

--- a/rosbot_utils/rosbot_utils/firmware_version.py
+++ b/rosbot_utils/rosbot_utils/firmware_version.py
@@ -1,0 +1,23 @@
+# Copyright 2024 Husarion sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single source of truth for the MCU firmware version shipped with this driver.
+
+The driver and the firmware are tightly coupled (see CLAUDE.md hard rule #6.1).
+Bumping this constant without also swapping the corresponding ``.bin`` files in
+``rosbot_utils/firmware/`` will break the firmware sanity check in
+``configure_robot`` and is a release-blocking error.
+"""
+
+FIRMWARE_VERSION: str = "v1.1.0-jazzy"

--- a/rosbot_utils/scripts/configure_robot
+++ b/rosbot_utils/scripts/configure_robot
@@ -20,6 +20,7 @@ import re
 import sys
 
 import serial
+from rosbot_utils.firmware_version import FIRMWARE_VERSION
 from rosbot_utils.mcu_manager_ftdi import McuManagerFTDI
 from rosbot_utils.mcu_manager_uart import McuManagerUART
 from rosbot_utils.utils import find_device_port
@@ -51,18 +52,16 @@ def configure_robot(port: str, namespace: str, baudrate: int, timeout: float = 5
             serial_port.close()
             return False
 
-        match = re.match(r"^FW:\s*v?(\d+)\.(\d+)\.(\d+)(?:-([\w\-]+))?$", line)
-        if not match:
+        banner_match = re.match(r"^FW:\s*(\S+)$", line)
+        if not banner_match:
             print_error(f"Unexpected response: {repr(line)}")
             serial_port.close()
             return False
 
-        expected_fw = "v1.1.0-jazzy"
-        suffix = f"-{match.group(4)}" if match.group(4) else ""
-        current_fw = f"v{'.'.join(match.groups()[:3])}{suffix}"
-        if current_fw != expected_fw:
+        current_fw = banner_match.group(1)
+        if not re.fullmatch(rf"FW:\s*{re.escape(FIRMWARE_VERSION)}", line):
             print_error(
-                f"Unsupported firmware: {current_fw} Expected: {expected_fw}. Run: ros2 run rosbot_utils flash_firmware --robot-model <rosbot/rosbot_xl>"
+                f"Unsupported firmware: {current_fw} Expected: {FIRMWARE_VERSION}. Run: ros2 run rosbot_utils flash_firmware --robot-model <rosbot/rosbot_xl>"
             )
             serial_port.close()
             return False

--- a/rosbot_utils/scripts/flash_firmware
+++ b/rosbot_utils/scripts/flash_firmware
@@ -20,6 +20,7 @@ import signal
 import sys
 
 from ament_index_python.packages import get_package_share_directory
+from rosbot_utils.firmware_version import FIRMWARE_VERSION
 from rosbot_utils.mcu_manager_ftdi import McuManagerFTDI
 from rosbot_utils.mcu_manager_uart import McuManagerUART
 
@@ -70,7 +71,9 @@ def main(args=None):
         args.usb = True
 
     rosbot_utils = get_package_share_directory("rosbot_utils")
-    robot_firmware = os.path.join(rosbot_utils, "firmware", robot_model + "-v1.1.0-jazzy.bin")
+    robot_firmware = os.path.join(
+        rosbot_utils, "firmware", f"{robot_model}-{FIRMWARE_VERSION}.bin"
+    )
     firmware = args.file if args.file else robot_firmware
     print(f"Using firmware file: {firmware}")
 


### PR DESCRIPTION
The firmware version string "v1.1.0-jazzy" previously appeared in three places: the .bin path build in flash_firmware, the banner regex/error message in configure_robot, and the actual .bin filenames under rosbot_utils/firmware/. Drift between the two scripts was easy to introduce on a firmware bump, undermining hard rule #6.1 ("Do not change the firmware version without swapping the binary").

Introduce a single source of truth at rosbot_utils.firmware_version (FIRMWARE_VERSION) and import it from both scripts. The .bin path is now composed at runtime as f"{robot_model}-{FIRMWARE_VERSION}.bin", and the configure_robot banner check is derived from the same constant via re.escape. The .bin files themselves are intentionally left in place with their existing names — the task only deduplicates the constant.

Semantics are unchanged: the same version is matched, the same file is flashed. A future firmware bump now touches exactly one Python constant plus the binaries.