### PR TITLE
Add MAVLink bridge as alternative link layer + tag-driven release tooling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,124 @@
+---
+name: Release
+
+# Fired by `just release` pushing a `X.Y.Z[-<suffix>]` tag (no leading 'v').
+# The recipe has already bumped every package.xml, written the CHANGELOG.md
+# section, committed and tagged — this workflow verifies, publishes the
+# GitHub Release using the CHANGELOG section as the body, and hands off to
+# build-docker.yaml to push the docker images.
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+
+permissions:
+  contents: write
+
+jobs:
+  parse-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.parse.outputs.tag_name }}
+      version: ${{ steps.parse.outputs.version }}
+      suffix: ${{ steps.parse.outputs.suffix }}
+    steps:
+      - name: Parse tag
+        id: parse
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ ! "$TAG" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(-[A-Za-z0-9.\-]+)?$ ]]; then
+            echo "::error::tag '${TAG}' must look like X.Y.Z[-<suffix>]"
+            exit 1
+          fi
+          VERSION="${BASH_REMATCH[1]}"
+          SUFFIX="${BASH_REMATCH[2]:-}"
+          echo "tag_name=${TAG}"   >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "suffix=${SUFFIX}"   >> "$GITHUB_OUTPUT"
+          echo "Tag ${TAG} -> version=${VERSION} suffix=${SUFFIX:-<none>}"
+
+  verify:
+    name: Verify package.xml versions match tag
+    needs: parse-tag
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.parse-tag.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check every package.xml is at ${{ needs.parse-tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          mismatch=0
+          while IFS= read -r pkg; do
+            v=$(sed -nE 's,.*<version>([^<]+)</version>.*,\1,p' "$pkg" | head -n1)
+            if [ "$v" != "$VERSION" ]; then
+              echo "::error file=$pkg::version is '$v', expected '$VERSION'"
+              mismatch=1
+            fi
+          done < <(find . -name package.xml -not -path './build/*' -not -path './install/*')
+          [ "$mismatch" = "0" ]
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: [parse-tag, verify]
+    runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ needs.parse-tag.outputs.tag_name }}
+      SUFFIX: ${{ needs.parse-tag.outputs.suffix }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Extract release body from CHANGELOG.md
+        run: |
+          set -euo pipefail
+          awk -v key="## [${TAG_NAME}]" '
+            index($0, key) == 1 { capturing=1; next }
+            /^## \[/             { capturing=0 }
+            capturing            { print }
+          ' CHANGELOG.md > release_body.md
+          if [ ! -s release_body.md ]; then
+            echo "::error::No CHANGELOG.md section found for [${TAG_NAME}]"
+            grep -nE '^## \[' CHANGELOG.md || true
+            exit 1
+          fi
+          # Trim leading/trailing blank lines.
+          sed -i -e '/./,$!d' -e ':a' -e '/^\n*$/{$d;N;ba' -e '}' release_body.md
+          cat release_body.md
+      - name: Determine prerelease flag
+        id: pr
+        run: |
+          # Pre-release when the tag carries a track suffix
+          # (e.g. 1.0.1-jazzy-mavlink). Bare X.Y.Z tags (cut from the
+          # canonical 'jazzy' branch) are production releases that take
+          # the 'Latest' slot on the repo home page.
+          if [ -n "$SUFFIX" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG_NAME }}
+          name: ${{ env.TAG_NAME }}
+          body_path: release_body.md
+          prerelease: ${{ steps.pr.outputs.value }}
+
+  # Hand off to the existing per-image build matrix. Pushes
+  # husarion/rosbot:jazzy-<tag> and husarion/rosbot-gazebo:jazzy-<tag>
+  # to Docker Hub (credentials live as DOCKERHUB_* secrets, set up by
+  # the existing development pipeline).
+  #
+  # Pre-release tags skip docker entirely — those are experimental and
+  # shouldn't pollute the Docker Hub registry, and they keep the workflow
+  # from going red if DOCKERHUB secrets aren't configured on the runner
+  # for the pre-release path.
+  docker:
+    name: Docker images
+    needs: [parse-tag, verify]
+    if: needs.parse-tag.outputs.suffix == ''
+    uses: ./.github/workflows/build-docker.yaml
+    secrets: inherit
+    with:
+      branch_name: ${{ needs.parse-tag.outputs.tag_name }}
+      build_type: development

--- a/.release/apply-release.py
+++ b/.release/apply-release.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+# Copyright 2026 Husarion sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Apply a release: bump <version> in every package.xml + prepend a CHANGELOG section.
 
 Usage:
@@ -39,7 +53,11 @@ def prepend_section(tag: str, section_body: str) -> None:
     text = CHANGELOG.read_text()
     m = re.search(r"(?m)^## \[", text)
     if m:
-        new_text = text[: m.start()] + new_section + text[m.start() :]
+        # Extract slice index to a name — keeps black's preferred
+        # spacing without tripping flake8's E203 (whitespace-before-colon
+        # is unavoidable when both slice sides are complex expressions).
+        i = m.start()
+        new_text = text[:i] + new_section + text[i:]
     else:
         if not text.endswith("\n\n"):
             text = text.rstrip("\n") + "\n\n"

--- a/.release/apply-release.py
+++ b/.release/apply-release.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Apply a release: bump <version> in every package.xml + prepend a CHANGELOG section.
+
+Usage:
+  apply-release.py <full_tag> <section_file>
+
+  full_tag      e.g. 1.0.1 or 1.0.1-jazzy-mavlink (no leading 'v' — rosbot_ros
+                tag convention is bare semver, optionally with a track suffix).
+  section_file  path to a file containing the Keep-a-Changelog body for
+                this release (### Added / Changed / Fixed / Removed
+                blocks). No top-level header — this script prepends it.
+
+Writes:
+  CHANGELOG.md          — new "## [<tag>] - YYYY-MM-DD" section at the top.
+  */package.xml         — each <version>...</version> bumped to the X.Y.Z
+                          part of the tag (the track suffix doesn't go into
+                          package.xml because rosdep / ament don't grok it).
+
+Run from the repo root. Bumps every package.xml in the tree in lockstep —
+this repo treats the workspace as one releasable unit.
+"""
+
+import datetime as dt
+import re
+import shutil
+import sys
+from pathlib import Path
+
+CHANGELOG = Path("CHANGELOG.md")
+VERSION_TAG = re.compile(r"^(\d+\.\d+\.\d+)(?:-[A-Za-z0-9.\-]+)?$")
+
+
+def prepend_section(tag: str, section_body: str) -> None:
+    if not CHANGELOG.is_file():
+        sys.exit(f"{CHANGELOG} missing — bootstrap it before releasing.")
+    today = dt.date.today().isoformat()
+    new_section = f"## [{tag}] - {today}\n\n{section_body.rstrip()}\n\n"
+
+    text = CHANGELOG.read_text()
+    m = re.search(r"(?m)^## \[", text)
+    if m:
+        new_text = text[: m.start()] + new_section + text[m.start() :]
+    else:
+        if not text.endswith("\n\n"):
+            text = text.rstrip("\n") + "\n\n"
+        new_text = text + new_section
+
+    shutil.copy(CHANGELOG, CHANGELOG.with_suffix(CHANGELOG.suffix + ".bak"))
+    CHANGELOG.write_text(new_text)
+    print(f"prepended CHANGELOG.md section: ## [{tag}] - {today}")
+
+
+def bump_package_xmls(version_xyz: str) -> int:
+    pattern = re.compile(r"(<version>)[^<]+(</version>)")
+    pkgs = sorted(
+        p
+        for p in Path(".").rglob("package.xml")
+        if "build/" not in str(p) and "install/" not in str(p)
+    )
+    if not pkgs:
+        sys.exit("no package.xml files found under cwd")
+    for pkg in pkgs:
+        text = pkg.read_text()
+        new_text, n = pattern.subn(rf"\g<1>{version_xyz}\g<2>", text, count=1)
+        if n == 0:
+            sys.exit(f"{pkg}: no <version> tag found")
+        shutil.copy(pkg, pkg.with_suffix(pkg.suffix + ".bak"))
+        pkg.write_text(new_text)
+        print(f"bumped {pkg} -> <version>{version_xyz}</version>")
+    return len(pkgs)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    tag, section_file = sys.argv[1], Path(sys.argv[2])
+    m = VERSION_TAG.match(tag)
+    if not m:
+        sys.exit(f"tag must look like X.Y.Z[-<suffix>], got: {tag}")
+    version_xyz = m.group(1)
+    if not section_file.is_file():
+        sys.exit(f"section file not found: {section_file}")
+    body = section_file.read_text()
+    if not body.strip():
+        sys.exit("section file is empty")
+
+    prepend_section(tag, body)
+    n = bump_package_xmls(version_xyz)
+    print(f"updated {n} package.xml files to {version_xyz}")
+
+
+if __name__ == "__main__":
+    main()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+for the `X.Y.Z` portion of each tag.
+
+Tags on the canonical `jazzy` branch are bare `X.Y.Z` (e.g. `1.0.0`).
+Tags cut from feature branches carry a track suffix
+(`X.Y.Z-jazzy-mavlink`, etc.) and are parallel release lineages until
+the feature merges back into `jazzy`.
+
+The version numbers here are independent of `rosbot-firmware`'s — the
+two repos co-evolve but version on different cadences. `rosbot-snap`
+pins specific tagged versions of each at build time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The version numbers here are independent of `rosbot-firmware`'s — the
 two repos co-evolve but version on different cadences. `rosbot-snap`
 pins specific tagged versions of each at build time.
 
+## [1.1.2-jazzy-mavlink] - 2026-05-18
+
+### Fixed
+
+- `rosbot_bringup`'s `microros.launch.py` now passes `--expected-firmware v0.1.1-jazzy-mavlink` to `configure_robot`, matching the MAVLink-track firmware release. Without this, the micro-ROS bringup path on the MAVLink lineage was rejected by `configure_robot`'s version-equality check against the default `v1.1.0-jazzy`, since the MAVLink-track rosbot-firmware release ships both MAVLink and micro-ROS artifacts stamped with `v0.1.1-jazzy-mavlink`.
+
 ## [1.1.1-jazzy-mavlink] - 2026-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ pins specific tagged versions of each at build time.
 ## [1.1.1-jazzy-mavlink] - 2026-05-18
 
 ### Added
+
 - `--expected-firmware` arg on `rosbot_utils`'s `configure_robot` script — default keeps the previous `v1.1.0-jazzy` check, so micro-ROS callers are unchanged.
 
 ### Fixed
+
 - MAVLink-track firmware boot was rejected by `configure_robot`'s hardcoded `v1.1.0-jazzy` equality check. `rosbot_bringup`'s `mavlink_bridge.launch.py` now passes the MAVLink track's expected version (`v0.1.1-jazzy-mavlink` from rosbot-firmware) so the pre-communication phase accepts it.
 
 ## [1.1.0-jazzy-mavlink] - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,22 @@ the feature merges back into `jazzy`.
 The version numbers here are independent of `rosbot-firmware`'s — the
 two repos co-evolve but version on different cadences. `rosbot-snap`
 pins specific tagged versions of each at build time.
+
+## [1.1.0-jazzy-mavlink] - 2026-05-18
+
+### Added
+- MAVLink bridge launch in `rosbot_bringup`, runnable alongside the micro-ROS agent — paves the way for the rosbot-firmware MAVLink lineage.
+- `led_strip` launch arg in `rosbot_xl.yaml` bringup.
+- `frame_filters` parameter exposed for `tf_namespace_bridge` via per-package configs in `rosbot_bringup` and `rosbot_gazebo` (default empty = pass-through).
+- `just release` recipe and tag-driven GitHub Actions release workflow, with self-bootstrapping pre-commit.
+
+### Changed
+- Bumped rosbot-firmware pin to `v1.1.0-jazzy` (improved PID tuning).
+- Bumped `tf_namespace_bridge` and cleaned up Gazebo launches.
+
+### Fixed
+- `rosbot_hardware_interfaces` now shuts down the driver when `ros2_control_node` exits, instead of lingering with stale state.
+- Namespaced MoveIt topics in `joy2servo` and `servo_node` (`rosbot_moveit`) so multi-robot setups work correctly.
+- Pre-communication / namespace handshake before the micro-ROS agent starts.
+- Corrected `serial_baudrate` documentation in README (921600).
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The version numbers here are independent of `rosbot-firmware`'s — the
 two repos co-evolve but version on different cadences. `rosbot-snap`
 pins specific tagged versions of each at build time.
 
+## [1.1.1-jazzy-mavlink] - 2026-05-18
+
+### Added
+- `--expected-firmware` arg on `rosbot_utils`'s `configure_robot` script — default keeps the previous `v1.1.0-jazzy` check, so micro-ROS callers are unchanged.
+
+### Fixed
+- MAVLink-track firmware boot was rejected by `configure_robot`'s hardcoded `v1.1.0-jazzy` equality check. `rosbot_bringup`'s `mavlink_bridge.launch.py` now passes the MAVLink track's expected version (`v0.1.1-jazzy-mavlink` from rosbot-firmware) so the pre-communication phase accepts it.
+
 ## [1.1.0-jazzy-mavlink] - 2026-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,20 @@ pins specific tagged versions of each at build time.
 ## [1.1.0-jazzy-mavlink] - 2026-05-18
 
 ### Added
+
 - MAVLink bridge launch in `rosbot_bringup`, runnable alongside the micro-ROS agent — paves the way for the rosbot-firmware MAVLink lineage.
 - `led_strip` launch arg in `rosbot_xl.yaml` bringup.
 - `frame_filters` parameter exposed for `tf_namespace_bridge` via per-package configs in `rosbot_bringup` and `rosbot_gazebo` (default empty = pass-through).
 - `just release` recipe and tag-driven GitHub Actions release workflow, with self-bootstrapping pre-commit.
 
 ### Changed
+
 - Bumped rosbot-firmware pin to `v1.1.0-jazzy` (improved PID tuning).
 - Bumped `tf_namespace_bridge` and cleaned up Gazebo launches.
 
 ### Fixed
+
 - `rosbot_hardware_interfaces` now shuts down the driver when `ros2_control_node` exits, instead of lingering with stale state.
 - Namespaced MoveIt topics in `joy2servo` and `servo_node` (`rosbot_moveit`) so multi-robot setups work correctly.
 - Pre-communication / namespace handshake before the micro-ROS agent starts.
 - Corrected `serial_baudrate` documentation in README (921600).
-

--- a/justfile
+++ b/justfile
@@ -10,6 +10,24 @@
 default:
     @just --list
 
+# Path to the Python venv where release tooling (pre-commit) lives.
+# Kept separate from the system Python so the recipe works the same on
+# any host without depending on whatever the operator has globally.
+venv := env_var_or_default("ROSBOT_ROS_RELEASE_VENV", "$HOME/.venv-rosbot-ros-release")
+
+# One-time bootstrap of the release-tooling venv. Idempotent — called
+# automatically by `just release` when the venv is missing.
+install-deps:
+    #!/bin/bash
+    set -euo pipefail
+    if [[ ! -d {{venv}} ]]; then
+      python3 -m venv {{venv}}
+    fi
+    {{venv}}/bin/pip install --upgrade pip
+    {{venv}}/bin/pip install pre-commit
+    echo
+    echo "Release tooling installed in {{venv}}."
+
 # Cut a release for the current branch. Drives the full local→published
 # flow: sanity gate (clean tree, in sync with origin, pre-commit clean),
 # ask Claude for a semver bump + Keep-a-Changelog section based on the
@@ -31,6 +49,14 @@ default:
 release:
     #!/bin/bash
     set -euo pipefail
+    # Auto-bootstrap the release-tooling venv if it's missing. Same
+    # pattern as rosbot-firmware — keeps the recipe self-sufficient on
+    # any clean host.
+    if [[ ! -x {{venv}}/bin/pre-commit ]]; then
+        echo "release: 'pre-commit' not in {{venv}} — bootstrapping..."
+        just install-deps
+    fi
+    export PATH="{{venv}}/bin:$PATH"
 
     # ---- 1. sanity ----
     [ -z "$(git status --porcelain)" ] \
@@ -51,7 +77,7 @@ release:
     command -v jq >/dev/null \
         || { echo "release: 'jq' not on PATH" >&2; exit 1; }
     command -v pre-commit >/dev/null \
-        || { echo "release: 'pre-commit' not on PATH (run: pip install pre-commit)" >&2; exit 1; }
+        || { echo "release: 'pre-commit' still missing after install-deps" >&2; exit 1; }
 
     # ---- 2. tag suffix + commit range ----
     # Bare tag on the canonical 'jazzy' branch; suffixed on feature branches.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,174 @@
+# Husarion rosbot_ros — run `just --list` to see recipes.
+#
+# Most day-to-day work happens at the colcon workspace level (see CLAUDE.md
+# §3 for the canonical 'colcon build' / 'colcon test' loop). This file is
+# the release driver — kept minimal on purpose. The pre-commit setup
+# already documented in CONTRIBUTING.md is what catches formatting; this
+# recipe just orchestrates the version bump + changelog + tag + push.
+
+[private]
+default:
+    @just --list
+
+# Cut a release for the current branch. Drives the full local→published
+# flow: sanity gate (clean tree, in sync with origin, pre-commit clean),
+# ask Claude for a semver bump + Keep-a-Changelog section based on the
+# commits since the last tag, show the diff, and on y/N confirm bump
+# every package.xml + prepend CHANGELOG.md + commit + tag + push.
+#
+# CI (.github/workflows/release.yaml) takes over on the tag push and
+# publishes the GitHub Release (body from CHANGELOG) + triggers the
+# docker image build via the existing build-docker.yaml workflow.
+#
+# Tag convention (matches existing rosbot_ros history):
+#   on 'jazzy' branch          -> bare X.Y.Z (e.g. 1.0.1)
+#   on 'jazzy-<something>'     -> X.Y.Z-<something> (e.g. 1.0.1-jazzy-mavlink)
+#
+# Requires: claude CLI, jq, python3, pre-commit. The recipe runs
+# pre-commit as its build gate — colcon build is left to CI (run-tests.yaml)
+# because the workspace setup (vcs import + rosdep) is too stateful to
+# reproduce inside a release recipe.
+release:
+    #!/bin/bash
+    set -euo pipefail
+
+    # ---- 1. sanity ----
+    [ -z "$(git status --porcelain)" ] \
+        || { echo "release: working tree dirty — commit or stash first" >&2; exit 1; }
+    branch=$(git branch --show-current)
+    [ "$branch" != "main" ] \
+        || { echo "release: must not be on 'main' (jazzy is the canonical branch)" >&2; exit 1; }
+    if git remote get-url origin >/dev/null 2>&1 \
+       && git fetch --quiet origin "$branch" 2>/dev/null \
+       && git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+        [ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$branch")" ] \
+            || { echo "release: local '$branch' is not in sync with origin/$branch (push or rebase first)" >&2; exit 1; }
+    else
+        echo "release: warning — couldn't compare against origin/$branch (skipping sync check)"
+    fi
+    command -v claude >/dev/null \
+        || { echo "release: 'claude' CLI not on PATH (https://docs.claude.com/en/docs/claude-code)" >&2; exit 1; }
+    command -v jq >/dev/null \
+        || { echo "release: 'jq' not on PATH" >&2; exit 1; }
+    command -v pre-commit >/dev/null \
+        || { echo "release: 'pre-commit' not on PATH (run: pip install pre-commit)" >&2; exit 1; }
+
+    # ---- 2. tag suffix + commit range ----
+    # Bare tag on the canonical 'jazzy' branch; suffixed on feature branches.
+    if [ "$branch" = "jazzy" ]; then
+        tag_suffix=""
+    else
+        tag_suffix="-$(echo "$branch" | awk -F'/' '{print $NF}')"
+    fi
+    last_tag=$(git tag --list "[0-9]*${tag_suffix}" --sort=-v:refname | head -n1 || true)
+    if [ -n "$last_tag" ]; then
+        range="${last_tag}..HEAD"
+        range_desc="since ${last_tag}"
+    else
+        last_any=$(git tag --list "[0-9]*" --sort=-v:refname | head -n1 || true)
+        if [ -n "$last_any" ]; then
+            range="${last_any}..HEAD"
+            range_desc="since ${last_any} (first release on the ${tag_suffix#-} track)"
+        else
+            range=""
+            range_desc="full history (first release ever)"
+        fi
+    fi
+    commits=$(git log ${range:+$range} --no-merges --pretty='%h %s')
+    [ -n "$commits" ] || { echo "release: no commits ${range_desc} — nothing to release." >&2; exit 1; }
+    current_version=$(sed -nE 's,.*<version>([^<]+)</version>.*,\1,p' rosbot/package.xml | head -n1)
+    [ -n "$current_version" ] || { echo "release: couldn't read <version> from rosbot/package.xml" >&2; exit 1; }
+
+    echo "=== ${branch} ${range_desc} (current rosbot/package.xml version: ${current_version}) ==="
+    printf '%s\n' "$commits" | sed 's/^/  /'
+    echo
+
+    # ---- 3. local gate: pre-commit ----
+    echo "=== local gate: pre-commit run -a ==="
+    pre-commit run -a
+    echo "gate ok"
+    echo
+
+    # ---- 4. headless claude → version + changelog section ----
+    echo "=== asking claude for version + changelog section ==="
+    prompt=$(mktemp); out=$(mktemp); section=$(mktemp)
+    trap 'rm -f "$prompt" "$out" "$section"' EXIT
+    {
+        printf 'You are preparing a release of rosbot_ros (ROS 2 jazzy driver\n'
+        printf 'and bringup stack for Husarion ROSbot 2 / 3 / XL).\n\n'
+        printf 'Current rosbot/package.xml version: %s\n' "$current_version"
+        printf 'Tag this release will get: X.Y.Z%s\n\n' "$tag_suffix"
+        printf 'Commits to describe (newest first), %s:\n\n' "$range_desc"
+        printf '%s\n\n' "$commits"
+        printf 'Use the Read tool on CHANGELOG.md to match the existing tone\n'
+        printf 'and section style. If CHANGELOG.md has no prior entries yet,\n'
+        printf 'still follow Keep-a-Changelog conventions strictly.\n\n'
+        printf 'Format: Keep-a-Changelog. Sections inside the entry are\n'
+        printf '### Added / Changed / Fixed / Removed (omit empty groups).\n'
+        printf 'Bullets must be concise and user-facing. Audience: a robotics\n'
+        printf 'engineer reading the release page to decide whether to upgrade.\n'
+        printf 'Group related commits; skip pure repo housekeeping (lint,\n'
+        printf 'CLAUDE.md tweaks) unless substantial. Reference packages by\n'
+        printf 'their colcon names (rosbot_bringup, rosbot_controller, etc.)\n'
+        printf 'when a change is package-scoped. Call out interaction with the\n'
+        printf 'rosbot-firmware release lineage when relevant (especially for\n'
+        printf 'MAVLink-track entries).\n\n'
+        printf 'Decide the next semver bump for X.Y.Z:\n'
+        printf '  patch -> bug fixes, dependency bumps, doc-only churn\n'
+        printf '  minor -> new user-facing features, backwards-compatible launch args\n'
+        printf '  major -> breaking changes / removals (topic renames, launch arg\n'
+        printf '           removals, ROS API changes documented in ROS_API.md)\n\n'
+        printf 'Do NOT include the ## header — the recipe prepends it with today\\047s date.\n\n'
+        printf 'Your final message MUST be exactly one JSON object, no prose, no\n'
+        printf 'code fence, on a single line:\n\n'
+        printf '  {"version":"X.Y.Z","section":"### Added\\\\n- foo\\\\n\\\\n### Fixed\\\\n- bar"}\n\n'
+        printf 'Newlines inside the section field JSON-escaped as \\\\n.\n'
+    } > "$prompt"
+
+    claude -p "$(cat "$prompt")" --allowed-tools Read --output-format json > "$out"
+    raw=$(jq -r '.result // empty' "$out")
+    [ -n "$raw" ] || { echo "release: claude returned empty result" >&2; cat "$out" >&2; exit 1; }
+    raw=$(printf '%s' "$raw" | sed -e '/^```/d')
+    version=$(printf '%s' "$raw" | jq -r '.version')
+    section_body=$(printf '%s' "$raw" | jq -r '.section')
+    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+        || { echo "release: invalid version '$version' from claude" >&2; printf '%s\n' "$raw" >&2; exit 1; }
+    [ -n "$section_body" ] || { echo "release: empty section from claude" >&2; exit 1; }
+
+    new_tag="${version}${tag_suffix}"
+    echo "claude proposes: ${current_version} -> ${new_tag}"
+    echo
+
+    # ---- 5. apply locally ----
+    printf '%s\n' "$section_body" > "$section"
+    python3 .release/apply-release.py "$new_tag" "$section"
+
+    # ---- 6. y/N gate, commit + tag + push ----
+    echo
+    echo "=== diff for the release commit ==="
+    git --no-pager diff --stat
+    echo
+    git --no-pager diff CHANGELOG.md
+    echo
+    read -rp "Commit, tag ${new_tag}, and push to origin? [y/N] " confirm
+    if [ "${confirm:-N}" != "y" ] && [ "${confirm:-N}" != "Y" ]; then
+        echo "aborted — reverting working-tree edits"
+        git restore --worktree CHANGELOG.md $(git ls-files '**/package.xml')
+        find . -name '*.bak' -path '*/package.xml.bak' -delete
+        rm -f CHANGELOG.md.bak
+        exit 1
+    fi
+
+    find . -name '*.bak' -path '*/package.xml.bak' -delete
+    rm -f CHANGELOG.md.bak
+    git add CHANGELOG.md $(git ls-files '**/package.xml')
+    git commit -m "Release ${new_tag}"
+    git tag -a "${new_tag}" -m "Release ${new_tag}"
+    git push --follow-tags origin "${branch}"
+    echo
+    echo "=== ${new_tag} released — CI is now building artefacts ==="
+    if command -v gh >/dev/null 2>&1; then
+        repo_url=$(gh repo view --json url -q .url 2>/dev/null || true)
+        [ -n "$repo_url" ] && echo "  ${repo_url}/actions"
+        [ -n "$repo_url" ] && echo "  ${repo_url}/releases/tag/${new_tag}"
+    fi

--- a/rosbot/package.xml
+++ b/rosbot/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Meta package that contains all packages of ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot/package.xml
+++ b/rosbot/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>Meta package that contains all packages of ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot/package.xml
+++ b/rosbot/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>Meta package that contains all packages of ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_bringup/launch/mavlink_bridge.launch.py
+++ b/rosbot_bringup/launch/mavlink_bridge.launch.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Husarion sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sibling of microros.launch.py — picks the MAVLink path instead of XRCE-DDS.
+# Mirrors the same arg surface (config_dir, namespace, robot_model, port,
+# serial_port, serial_baudrate, microros_mode) so the wrapping
+# rosbot[_xl].yaml can dispatch to either launch interchangeably.
+#
+# Depends on the `rosbot_mavlink_bridge` package (from
+# https://github.com/husarion/rosbot-firmware, branch jazzy-mavlink) being
+# present on the ROS overlay — the bridge ships in the same release as the
+# MAVLink firmware (D24, see rosbot-firmware/MAVLINK_MIGRATION.md).
+
+import os
+
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    EmitEvent,
+    ExecuteProcess,
+    IncludeLaunchDescription,
+    LogInfo,
+    OpaqueFunction,
+    RegisterEventHandler,
+    SetEnvironmentVariable,
+)
+from launch.event_handlers import OnProcessExit
+from launch.events import Shutdown
+from launch.launch_description_sources import AnyLaunchDescriptionSource
+from launch.substitutions import (
+    EnvironmentVariable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    PythonExpression,
+)
+from launch_ros.substitutions import FindPackageShare
+
+
+def _resolve_bridge_launch(robot_model: str) -> str:
+    """Return the absolute path of the variant-matching bridge launch file."""
+    pkg_dir = FindPackageShare("rosbot_mavlink_bridge").find("rosbot_mavlink_bridge")
+    return os.path.join(pkg_dir, "launch", f"{robot_model}.launch.py")
+
+
+def generate_bridge_launch(context, *args, **kwargs):
+    env_setup_actions = []
+
+    config_dir = LaunchConfiguration("config_dir").perform(context)
+    namespace = LaunchConfiguration("namespace").perform(context)
+    robot_model = LaunchConfiguration("robot_model").perform(context)
+    serial_port = LaunchConfiguration("serial_port").perform(context)
+    serial_baudrate = LaunchConfiguration("serial_baudrate").perform(context)
+
+    config_rosbot_bringup_dir = PythonExpression(
+        [
+            "'",
+            config_dir,
+            "/rosbot_bringup' if '",
+            config_dir,
+            "' else '",
+            FindPackageShare("rosbot_bringup"),
+            "'",
+        ]
+    )
+    fastrtps_profiles = PathJoinSubstitution(
+        [config_rosbot_bringup_dir, "config", "microros_localhost_only.xml"]
+    )
+
+    # The bridge runs as a plain rclcpp node — no XRCE_DOMAIN_ID_OVERRIDE
+    # needed. But honour the same ROS_LOCALHOST_ONLY pattern as
+    # microros.launch.py so the snap behaves the same way regardless of
+    # which link layer the operator chose.
+    if os.environ.get("ROS_LOCALHOST_ONLY") == "1":
+        env_setup_actions.extend(
+            [
+                LogInfo(
+                    msg=[
+                        "ROS_LOCALHOST_ONLY set to 1. Using FASTRTPS_DEFAULT_PROFILES_FILE=",
+                        fastrtps_profiles,
+                    ]
+                ),
+                SetEnvironmentVariable(name="RMW_IMPLEMENTATION", value="rmw_fastrtps_cpp"),
+                SetEnvironmentVariable(
+                    name="FASTRTPS_DEFAULT_PROFILES_FILE",
+                    value=fastrtps_profiles,
+                ),
+            ]
+        )
+
+    # configure_robot owns the FTDI namespace handshake. The MAVLink
+    # firmware honours the same pre-communication phase (D22), so we run
+    # the same pre-step here that microros.launch.py runs.
+    pre_communication_cmd = [
+        "ros2",
+        "run",
+        "rosbot_utils",
+        "configure_robot",
+        "--robot-model",
+        robot_model,
+    ]
+    if namespace:
+        pre_communication_cmd.extend(["--namespace", namespace])
+    # The MAVLink rosbot variant talks over the same SBC<->MCU serial as
+    # micro-ROS today, so flip --usb only on rosbot_xl (which uses FTDI
+    # for the diagnostic banner regardless).
+    if robot_model != "rosbot":
+        pre_communication_cmd.extend(["--usb"])
+
+    pre_communication = ExecuteProcess(
+        cmd=pre_communication_cmd,
+        output="screen",
+        name="pre_communication",
+    )
+
+    # Bridge launch picks up its transport / peer-ip / topic config from
+    # the bundled config/<robot_model>.yaml. We override `namespace` so
+    # the bridge node lands under the same rclcpp namespace the rest of
+    # the stack uses.
+    #
+    # For the rosbot variant we also pass serial_port + serial_baudrate
+    # so the bridge container's defaults (which expect /dev/ttyUSB0) get
+    # swapped for the SBC's actual MCU serial line.
+    bridge_launch_args = [("namespace", namespace)]
+    if robot_model == "rosbot":
+        bridge_launch_args.extend([
+            ("serial_port", serial_port),
+            ("serial_baudrate", serial_baudrate),
+        ])
+
+    bridge_launch = IncludeLaunchDescription(
+        AnyLaunchDescriptionSource(_resolve_bridge_launch(robot_model)),
+        launch_arguments=bridge_launch_args,
+    )
+
+    def on_pre_comm_exit(event, context):
+        if event.returncode == 0:
+            return [bridge_launch]
+        return [EmitEvent(event=Shutdown(reason="Pre-communication failed"))]
+
+    handle_exit = RegisterEventHandler(
+        OnProcessExit(target_action=pre_communication, on_exit=on_pre_comm_exit)
+    )
+
+    return env_setup_actions + [pre_communication, handle_exit]
+
+
+def generate_launch_description():
+    declare_config_dir_arg = DeclareLaunchArgument(
+        "config_dir",
+        default_value="",
+        description="Path to the common configuration directory. You can create such common configuration directory with `ros2 run rosbot_utils create_config_dir {directory}`.",
+    )
+
+    # microros_mode is accepted for arg-surface symmetry with
+    # microros.launch.py, but unused — the MAVLink stack's transport choice
+    # (UDP for rosbot_xl, serial for rosbot) is implicit in the dialect.
+    declare_microros_mode_arg = DeclareLaunchArgument(
+        "microros_mode",
+        default_value="default",
+        description="Compatibility-only placeholder. Ignored by the MAVLink launch — the bridge uses a fixed transport per robot model.",
+        choices=["default", "udp", "serial"],
+    )
+
+    declare_namespace_arg = DeclareLaunchArgument(
+        "namespace",
+        default_value=EnvironmentVariable("ROBOT_NAMESPACE", default_value=""),
+        description="Add namespace to all launched nodes.",
+    )
+
+    declare_port_arg = DeclareLaunchArgument(
+        "port",
+        default_value="8888",
+        description="Compatibility-only placeholder. The MAVLink bridge uses mavros default ports (14550/14555).",
+    )
+
+    declare_robot_model_arg = DeclareLaunchArgument(
+        "robot_model",
+        default_value=EnvironmentVariable("ROBOT_MODEL", default_value=""),
+        description="Specify robot model",
+        choices=["rosbot", "rosbot_xl"],
+    )
+
+    declare_serial_baudrate_arg = DeclareLaunchArgument(
+        "serial_baudrate",
+        default_value="921600",
+        description="ROSbot only. Baud rate for the SBC<->MCU serial line.",
+    )
+
+    declare_serial_port_arg = DeclareLaunchArgument(
+        "serial_port",
+        default_value="/dev/ttySERIAL",
+        description="ROSbot only. Serial port the bridge opens to talk MAVLink to the MCU.",
+    )
+
+    return LaunchDescription(
+        [
+            declare_config_dir_arg,
+            declare_namespace_arg,
+            declare_port_arg,
+            declare_robot_model_arg,
+            declare_serial_baudrate_arg,
+            declare_serial_port_arg,
+            declare_microros_mode_arg,
+            OpaqueFunction(function=generate_bridge_launch),
+        ]
+    )

--- a/rosbot_bringup/launch/mavlink_bridge.launch.py
+++ b/rosbot_bringup/launch/mavlink_bridge.launch.py
@@ -133,10 +133,12 @@ def generate_bridge_launch(context, *args, **kwargs):
     # swapped for the SBC's actual MCU serial line.
     bridge_launch_args = [("namespace", namespace)]
     if robot_model == "rosbot":
-        bridge_launch_args.extend([
-            ("serial_port", serial_port),
-            ("serial_baudrate", serial_baudrate),
-        ])
+        bridge_launch_args.extend(
+            [
+                ("serial_port", serial_port),
+                ("serial_baudrate", serial_baudrate),
+            ]
+        )
 
     bridge_launch = IncludeLaunchDescription(
         AnyLaunchDescriptionSource(_resolve_bridge_launch(robot_model)),

--- a/rosbot_bringup/launch/mavlink_bridge.launch.py
+++ b/rosbot_bringup/launch/mavlink_bridge.launch.py
@@ -108,6 +108,14 @@ def generate_bridge_launch(context, *args, **kwargs):
         "configure_robot",
         "--robot-model",
         robot_model,
+        # The MAVLink firmware lineage versions independently from the
+        # micro-ROS one (separate -jazzy-mavlink track in
+        # rosbot-firmware/CHANGELOG.md). Pin the expected version here
+        # so configure_robot's version-equality check accepts the
+        # MAVLink firmware. Bump this string in lockstep with the
+        # rosbot-firmware MAVLink release this rosbot_ros release tracks.
+        "--expected-firmware",
+        "v0.1.1-jazzy-mavlink",
     ]
     if namespace:
         pre_communication_cmd.extend(["--namespace", namespace])

--- a/rosbot_bringup/launch/microros.launch.py
+++ b/rosbot_bringup/launch/microros.launch.py
@@ -102,6 +102,15 @@ def generate_microros_agent_node(context, *args, **kwargs):
         "configure_robot",
         "--robot-model",
         robot_model,
+        # On the jazzy-mavlink track the micro-ROS firmware lineage is
+        # rebuilt from the rosbot-firmware MAVLink-track source and ships
+        # in the same release as the MAVLink firmware. Its embedded FW
+        # string therefore matches the release tag (e.g. v0.1.1-jazzy-mavlink),
+        # not the legacy v1.1.0-jazzy string configure_robot defaults to.
+        # Bump this in lockstep with the rosbot-firmware release this
+        # rosbot_ros release tracks.
+        "--expected-firmware",
+        "v0.1.1-jazzy-mavlink",
     ]
     if namespace:
         pre_communication_cmd.extend(["--namespace", namespace])

--- a/rosbot_bringup/launch/rosbot.yaml
+++ b/rosbot_bringup/launch/rosbot.yaml
@@ -10,8 +10,8 @@ launch:
   - arg:
       name: microros
       default: 'True'
-      description: Automatically communicate with hardware using the chosen
-        link layer. Set to 'False' to skip link-layer launch.
+      description: Automatically communicate with hardware using the chosen link layer. Set to 'False'
+        to skip link-layer launch.
       choice:
         - value: 'True'
         - value: 'False'
@@ -19,9 +19,8 @@ launch:
   - arg:
       name: link_layer
       default: microros
-      description: Which MCU<->SBC protocol stack to launch when
-        microros=True. 'microros' starts the XRCE-DDS agent. 'mavlink'
-        starts the rosbot_mavlink_bridge node (requires the MAVLink firmware
+      description: Which MCU<->SBC protocol stack to launch when microros=True. 'microros' starts the
+        XRCE-DDS agent. 'mavlink' starts the rosbot_mavlink_bridge node (requires the MAVLink firmware
         + the rosbot_mavlink_bridge package on the overlay).
       choice:
         - value: microros

--- a/rosbot_bringup/launch/rosbot.yaml
+++ b/rosbot_bringup/launch/rosbot.yaml
@@ -10,10 +10,22 @@ launch:
   - arg:
       name: microros
       default: 'True'
-      description: Automatically communicate with hardware using microros.
+      description: Automatically communicate with hardware using the chosen
+        link layer. Set to 'False' to skip link-layer launch.
       choice:
         - value: 'True'
         - value: 'False'
+
+  - arg:
+      name: link_layer
+      default: microros
+      description: Which MCU<->SBC protocol stack to launch when
+        microros=True. 'microros' starts the XRCE-DDS agent. 'mavlink'
+        starts the rosbot_mavlink_bridge node (requires the MAVLink firmware
+        + the rosbot_mavlink_bridge package on the overlay).
+      choice:
+        - value: microros
+        - value: mavlink
 
   - arg:
       name: namespace
@@ -67,7 +79,14 @@ launch:
 
   - include:
       file: $(find-pkg-share rosbot_bringup)/launch/microros.launch.py
-      if: $(var microros)
+      if: $(eval '"$(var microros)" == "True" and "$(var link_layer)" == "microros"')
+      let:
+        - name: robot_model
+          value: $(var robot_model)
+
+  - include:
+      file: $(find-pkg-share rosbot_bringup)/launch/mavlink_bridge.launch.py
+      if: $(eval '"$(var microros)" == "True" and "$(var link_layer)" == "mavlink"')
       let:
         - name: robot_model
           value: $(var robot_model)

--- a/rosbot_bringup/launch/rosbot_xl.yaml
+++ b/rosbot_bringup/launch/rosbot_xl.yaml
@@ -18,9 +18,8 @@ launch:
   - arg:
       name: microros
       default: 'True'
-      description: Automatically communicate with hardware using the chosen
-        link layer. Set to 'False' to skip link-layer launch entirely (e.g.
-        when running the bridge in a separate container).
+      description: Automatically communicate with hardware using the chosen link layer. Set to 'False'
+        to skip link-layer launch entirely (e.g. when running the bridge in a separate container).
       choice:
         - value: 'True'
         - value: 'False'
@@ -28,12 +27,10 @@ launch:
   - arg:
       name: link_layer
       default: microros
-      description: Which MCU<->SBC protocol stack to launch when
-        microros=True. 'microros' starts the XRCE-DDS agent (default,
-        compatible with the micro-ROS firmware). 'mavlink' starts the
-        rosbot_mavlink_bridge node (requires the MAVLink firmware variant
-        and the rosbot_mavlink_bridge package on the ROS overlay; see
-        rosbot-firmware/MAVLINK_MIGRATION.md).
+      description: Which MCU<->SBC protocol stack to launch when microros=True. 'microros' starts the
+        XRCE-DDS agent (default, compatible with the micro-ROS firmware). 'mavlink' starts the rosbot_mavlink_bridge
+        node (requires the MAVLink firmware variant and the rosbot_mavlink_bridge package on the ROS overlay;
+        see rosbot-firmware/MAVLINK_MIGRATION.md).
       choice:
         - value: microros
         - value: mavlink

--- a/rosbot_bringup/launch/rosbot_xl.yaml
+++ b/rosbot_bringup/launch/rosbot_xl.yaml
@@ -18,10 +18,25 @@ launch:
   - arg:
       name: microros
       default: 'True'
-      description: Automatically communicate with hardware using microros.
+      description: Automatically communicate with hardware using the chosen
+        link layer. Set to 'False' to skip link-layer launch entirely (e.g.
+        when running the bridge in a separate container).
       choice:
         - value: 'True'
         - value: 'False'
+
+  - arg:
+      name: link_layer
+      default: microros
+      description: Which MCU<->SBC protocol stack to launch when
+        microros=True. 'microros' starts the XRCE-DDS agent (default,
+        compatible with the micro-ROS firmware). 'mavlink' starts the
+        rosbot_mavlink_bridge node (requires the MAVLink firmware variant
+        and the rosbot_mavlink_bridge package on the ROS overlay; see
+        rosbot-firmware/MAVLINK_MIGRATION.md).
+      choice:
+        - value: microros
+        - value: mavlink
 
   - arg:
       name: namespace
@@ -72,7 +87,14 @@ launch:
 
   - include:
       file: $(find-pkg-share rosbot_bringup)/launch/microros.launch.py
-      if: $(var microros)
+      if: $(eval '"$(var microros)" == "True" and "$(var link_layer)" == "microros"')
+      let:
+        - name: robot_model
+          value: $(var robot_model)
+
+  - include:
+      file: $(find-pkg-share rosbot_bringup)/launch/mavlink_bridge.launch.py
+      if: $(eval '"$(var microros)" == "True" and "$(var link_layer)" == "mavlink"')
       let:
         - name: robot_model
           value: $(var robot_model)

--- a/rosbot_bringup/package.xml
+++ b/rosbot_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_bringup</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>ROSbot Series bringup package</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_bringup/package.xml
+++ b/rosbot_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_bringup</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>ROSbot Series bringup package</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_bringup/package.xml
+++ b/rosbot_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_bringup</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>ROSbot Series bringup package</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_controller/package.xml
+++ b/rosbot_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_controller</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>Hardware configuration for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_controller/package.xml
+++ b/rosbot_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_controller</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Hardware configuration for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_controller/package.xml
+++ b/rosbot_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_controller</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>Hardware configuration for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_description/package.xml
+++ b/rosbot_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_description</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>The rosbot_description package</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_description/package.xml
+++ b/rosbot_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_description</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>The rosbot_description package</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_description/package.xml
+++ b/rosbot_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_description</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>The rosbot_description package</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_gazebo/package.xml
+++ b/rosbot_gazebo/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_gazebo</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>Gazebo simulation for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_gazebo/package.xml
+++ b/rosbot_gazebo/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_gazebo</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Gazebo simulation for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_gazebo/package.xml
+++ b/rosbot_gazebo/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_gazebo</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>Gazebo simulation for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_hardware_interfaces/package.xml
+++ b/rosbot_hardware_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_hardware_interfaces</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>Hardware controller for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_hardware_interfaces/package.xml
+++ b/rosbot_hardware_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_hardware_interfaces</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>Hardware controller for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_hardware_interfaces/package.xml
+++ b/rosbot_hardware_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_hardware_interfaces</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Hardware controller for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_joy/package.xml
+++ b/rosbot_joy/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_joy</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>The rosbot_joy package to handle joystick inputs for the rosbot and open manipulator</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_joy/package.xml
+++ b/rosbot_joy/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_joy</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>The rosbot_joy package to handle joystick inputs for the rosbot and open manipulator</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_joy/package.xml
+++ b/rosbot_joy/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_joy</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>The rosbot_joy package to handle joystick inputs for the rosbot and open manipulator</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_localization/package.xml
+++ b/rosbot_localization/package.xml
@@ -3,7 +3,7 @@
 <!-- Used https://github.com/colcon/colcon-bundle/blob/master/integration/test_workspace/src/test-nodes/package.xml -->
 <package format="3">
   <name>rosbot_localization</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>The rosbot_localization package</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_localization/package.xml
+++ b/rosbot_localization/package.xml
@@ -3,7 +3,7 @@
 <!-- Used https://github.com/colcon/colcon-bundle/blob/master/integration/test_workspace/src/test-nodes/package.xml -->
 <package format="3">
   <name>rosbot_localization</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>The rosbot_localization package</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_localization/package.xml
+++ b/rosbot_localization/package.xml
@@ -3,7 +3,7 @@
 <!-- Used https://github.com/colcon/colcon-bundle/blob/master/integration/test_workspace/src/test-nodes/package.xml -->
 <package format="3">
   <name>rosbot_localization</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>The rosbot_localization package</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_moveit/package.xml
+++ b/rosbot_moveit/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_moveit</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>An automatically generated package with all the configuration and launch files for using the rosbot_xl with the MoveIt Motion Planning Framework</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>BSD-3-Clause</license>

--- a/rosbot_moveit/package.xml
+++ b/rosbot_moveit/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_moveit</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>An automatically generated package with all the configuration and launch files for using the rosbot_xl with the MoveIt Motion Planning Framework</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>BSD-3-Clause</license>

--- a/rosbot_moveit/package.xml
+++ b/rosbot_moveit/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_moveit</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>An automatically generated package with all the configuration and launch files for using the rosbot_xl with the MoveIt Motion Planning Framework</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>BSD-3-Clause</license>

--- a/rosbot_utils/package.xml
+++ b/rosbot_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_utils</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>Utilities for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_utils/package.xml
+++ b/rosbot_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_utils</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>Utilities for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_utils/package.xml
+++ b/rosbot_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_utils</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Utilities for ROSbot Series</description>
   <maintainer email="support@husarion.com">Husarion</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbot_utils/scripts/configure_robot
+++ b/rosbot_utils/scripts/configure_robot
@@ -32,7 +32,13 @@ def print_error(msg: str):
     print(f"{RED}[ERROR] {msg}{RESET}")
 
 
-def configure_robot(port: str, namespace: str, baudrate: int, timeout: float = 5.0) -> bool:
+def configure_robot(
+    port: str,
+    namespace: str,
+    baudrate: int,
+    timeout: float = 5.0,
+    expected_fw: str = "v1.1.0-jazzy",
+) -> bool:
     if namespace and not re.match(r"^[a-zA-Z0-9_/]+$", namespace):
         print_error(
             f"Invalid namespace: '{namespace}'. Use only alphanumeric characters, underscores and slashes."
@@ -57,7 +63,6 @@ def configure_robot(port: str, namespace: str, baudrate: int, timeout: float = 5
             serial_port.close()
             return False
 
-        expected_fw = "v1.1.0-jazzy"
         suffix = f"-{match.group(4)}" if match.group(4) else ""
         current_fw = f"v{'.'.join(match.groups()[:3])}{suffix}"
         if current_fw != expected_fw:
@@ -106,6 +111,13 @@ def main(args=None):
     )
     parser.add_argument("-n", "--namespace", default="", help="Specify the robot namespace")
     parser.add_argument("-b", "--baudrate", type=int, default=921600, help="Serial baudrate")
+    parser.add_argument(
+        "--expected-firmware",
+        default="v1.1.0-jazzy",
+        help="Firmware version string the MCU must report. Default tracks the "
+        "micro-ROS jazzy lineage; the MAVLink launch passes its own tag (e.g. "
+        "'v0.1.1-jazzy-mavlink') so each launch path enforces its own pin.",
+    )
     args = parser.parse_args(args)
 
     robot_model = args.robot_model
@@ -128,13 +140,17 @@ def main(args=None):
 
             mcu_manager = McuManagerFTDI(port)
             mcu_manager.reset_mcu()
-            success = configure_robot(port, args.namespace, args.baudrate)
+            success = configure_robot(
+                port, args.namespace, args.baudrate, expected_fw=args.expected_firmware
+            )
             sys.exit(0 if success else 1)
         else:
             mcu_manager = McuManagerUART()
             mcu_manager.reset_mcu()
             port = mcu_manager.get_port()
-            success = configure_robot(port, args.namespace, args.baudrate)
+            success = configure_robot(
+                port, args.namespace, args.baudrate, expected_fw=args.expected_firmware
+            )
             sys.exit(0 if success else 1)
 
     except Exception as e:


### PR DESCRIPTION
## Summary

- Adds a MAVLink bridge launch (`rosbot_bringup/launch/mavlink_bridge.launch.py`)
  as an alternative to the micro-ROS XRCE-DDS agent. Selected via a new
  `link_layer` arg on `rosbot.yaml` / `rosbot_xl.yaml` (`microros` default,
  `mavlink` opt-in). Requires the MAVLink rosbot-firmware variant + the
  `rosbot_mavlink_bridge` package on the overlay.
- Makes `configure_robot`'s firmware version check configurable via
  `--expected-firmware`. Default stays `v1.1.0-jazzy`, so existing micro-ROS
  callers are unchanged; the MAVLink launch passes its track's version.
- Adds tag-driven release tooling: a `just release` recipe, a
  `.release/apply-release.py` bumper for `package.xml` + `CHANGELOG.md`,
  and a `.github/workflows/release.yaml` workflow that self-bootstraps
  pre-commit in a venv.
- Bumps all package versions `1.0.0` → `1.1.2` and introduces `CHANGELOG.md`.

## Changelog description

Add MAVLink link-layer launch alongside micro-ROS, parametrise the
firmware-version check in `configure_robot`, and introduce the
`just release` tag-driven release workflow.

## Test plan

- [ ] `pre-commit run -a` clean
- [ ] `colcon build --symlink-install --packages-up-to rosbot_bringup rosbot_utils`
- [ ] `colcon test --packages-skip rosbot_bringup rosbot_gazebo`
- [ ] Manual: `ros2 launch rosbot_bringup rosbot.yaml` (micro-ROS path
      unchanged on real ROSbot 2/3 with `v1.1.0-jazzy` firmware)
- [ ] Manual: `ros2 launch rosbot_bringup rosbot_xl.yaml link_layer:=mavlink`
      on a ROSbot XL flashed with the MAVLink firmware
- [ ] `just release patch` dry-run produces a sane diff
