### PR TITLE
Add rosbot-firmware to vcs + auto-merge for firmware bumps

### DIFF
--- a/.github/workflows/firmware-bump-automerge.yaml
+++ b/.github/workflows/firmware-bump-automerge.yaml
@@ -1,0 +1,29 @@
+---
+# Enable GitHub auto-merge (squash) on PRs labelled auto-firmware-bump.
+# Needs repo Allow auto-merge + branch protection with a required
+# status check on jazzy-mavlink-v2. Add block-automerge to pause.
+name: Firmware bump auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, labeled, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'auto-firmware-bump') &&
+      !contains(github.event.pull_request.labels.*.name, 'block-automerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr merge --auto --squash --delete-branch "$PR_NUMBER" -R "$REPO"

--- a/.github/workflows/firmware-bump-automerge.yaml
+++ b/.github/workflows/firmware-bump-automerge.yaml
@@ -1,7 +1,8 @@
 ---
 # Enable GitHub auto-merge (squash) on PRs labelled auto-firmware-bump.
-# Needs repo Allow auto-merge + branch protection with a required
-# status check on jazzy-mavlink-v2. Add block-automerge to pause.
+# Needs repo Allow auto-merge + branch protection with required checks
+# on jazzy-mavlink-v2; without them the job fail-softs (warn + admin
+# checklist in Job Summary, exit 0). Add block-automerge to pause.
 name: Firmware bump auto-merge
 
 on:
@@ -19,11 +20,36 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'block-automerge')
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge (squash)
+      - name: Try to enable auto-merge (squash)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          set -euo pipefail
-          gh pr merge --auto --squash --delete-branch "$PR_NUMBER" -R "$REPO"
+          set -uo pipefail  # no -e: failure handled below
+
+          OUT=$(mktemp)
+          if gh pr merge --auto --squash --delete-branch \
+                  "$PR_NUMBER" -R "$REPO" >"$OUT" 2>&1; then
+              echo "Auto-merge enabled for PR #$PR_NUMBER."
+              cat "$OUT"
+              exit 0
+          fi
+
+          echo "::warning title=Auto-merge could not be enabled::PR #$PR_NUMBER needs manual merge until repo settings are configured."
+
+          {
+              echo "## :warning: Auto-merge could not be enabled on PR #$PR_NUMBER"
+              echo
+              echo "### Admin setup (one-off)"
+              echo "1. Settings → General → Allow auto-merge: ON"
+              echo "2. Settings → Branches: branch protection on \`$BASE_REF\` with a required status check"
+              echo
+              echo "### \`gh\` output"
+              echo "\`\`\`"
+              cat "$OUT"
+              echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit 0

--- a/rosbot/rosbot_hardware.repos
+++ b/rosbot/rosbot_hardware.repos
@@ -11,6 +11,13 @@ repositories:
     type: git
     url: https://github.com/micro-ROS/micro-ROS-Agent
     version: af007872b034d1ed31de4815377031350ab0034b
+  # Builds rosbot_mavlink_bridge (runtime dep of mavlink.launch.py).
+  # Flashing still uses bundled .bin in rosbot_utils/firmware/.
+  # `version` is auto-bumped by rosbot-firmware's release workflow.
+  rosbot-firmware:
+    type: git
+    url: https://github.com/husarion/rosbot-firmware.git
+    version: v0.1.1-jazzy-mavlink
   tf_namespace_bridge:
     type: git
     url: https://github.com/husarion/tf_namespace_bridge


### PR DESCRIPTION
## Changelog description

- Add `rosbot-firmware` to `rosbot_hardware.repos` so `vcs import`
  fetches firmware sources + `rosbot_mavlink_bridge` automatically.
- Add `firmware-bump-automerge.yaml` — GitHub auto-merge (squash) on
  PRs labelled `auto-firmware-bump`, fail-soft when repo settings
  aren't configured.

## Summary

- `rosbot-firmware` pinned to `v0.1.1-jazzy-mavlink`; the only ROS
  package inside is `bridge/rosbot_mavlink_bridge` (runtime dep of
  `mavlink.launch.py`). Bundled `.bin` files in
  `rosbot_utils/firmware/` stay the source of truth for flashing.
  `version:` is auto-bumped by rosbot-firmware's release pipeline.
- Auto-merge workflow triggers on `pull_request_target` for the
  `auto-firmware-bump` label and calls
  `gh pr merge --auto --squash --delete-branch`. Add `block-automerge`
  to pause a PR.
- Fail-soft: if *Allow auto-merge* or branch protection is missing,
  emit `::warning::` + admin checklist in Job Summary, exit 0 (yellow
  run, not red). PR stays open and human-mergeable.

## Admin setup (one-off)

- Settings → General → **Allow auto-merge**: ON
- Settings → Branches: protection on `jazzy-mavlink-v2` with at
  least one required status check

## Test plan

- [x] `pre-commit run --files` on both changed files — clean
- [ ] Workflow run on a real firmware-bump PR (exercises fail-soft
      until admin settings are flipped)