### PR TITLE
automerge: trigger on `unlabeled` so removing block-automerge takes effect

### DIFF
--- a/.github/workflows/firmware-bump-automerge.yaml
+++ b/.github/workflows/firmware-bump-automerge.yaml
@@ -1,13 +1,30 @@
 ---
-# Enable GitHub auto-merge (squash) on PRs labelled auto-firmware-bump.
-# Needs repo Allow auto-merge + branch protection with required checks
-# on jazzy-mavlink-v2; without them the job fail-softs (warn + admin
-# checklist in Job Summary, exit 0). Add block-automerge to pause.
+# Try to enable GitHub's native auto-merge (squash) on firmware-bump PRs
+# that rosbot-firmware's release workflow opens here. Once enabled,
+# GitHub server-side waits for the required checks (`integration` etc.)
+# to pass and merges the PR. If a check fails, auto-merge stays armed
+# and waits for a green re-run — it never merges over a red check. To
+# block a specific PR from auto-merging, add the `block-automerge` label.
+#
+# Setup prerequisites (manual, one-off, can't be automated from here):
+#   Repo Settings -> General -> "Allow auto-merge" must be ON, and the
+#   target branch (`jazzy-mavlink-v2`) needs branch protection with at
+#   least one required status check.
+#
+# Without those settings, GitHub refuses to enable auto-merge. The job
+# then emits a workflow `::warning::` annotation + writes an actionable
+# checklist to the run's Job Summary, and exits 0 — so the workflow run
+# stays green (yellow warning, not red failure). The PR is still open
+# and reviewable; a human just has to merge it manually. Once an admin
+# flips the settings, future PRs auto-merge on their own.
 name: Firmware bump auto-merge
 
 on:
   pull_request_target:
-    types: [opened, labeled, reopened, synchronize]
+    # `unlabeled` is here so removing `block-automerge` (after a human
+    # finishes the manual edits on a breaking-change PR) re-triggers the
+    # job and enables auto-merge for the remainder of the CI cycle.
+    types: [opened, labeled, unlabeled, reopened, synchronize]
 
 permissions:
   contents: write
@@ -27,7 +44,7 @@ jobs:
           REPO: ${{ github.repository }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          set -uo pipefail  # no -e: failure handled below
+          set -uo pipefail  # NB: no -e — we handle the failure ourselves.
 
           OUT=$(mktemp)
           if gh pr merge --auto --squash --delete-branch \
@@ -37,19 +54,30 @@ jobs:
               exit 0
           fi
 
-          echo "::warning title=Auto-merge could not be enabled::PR #$PR_NUMBER needs manual merge until repo settings are configured."
+          rc=$?
+          echo "::warning title=Auto-merge could not be enabled::gh pr merge --auto exited with code $rc. PR #$PR_NUMBER is open but a human needs to merge it (or an admin needs to enable the repo settings below)."
 
           {
               echo "## :warning: Auto-merge could not be enabled on PR #$PR_NUMBER"
               echo
-              echo "### Admin setup (one-off)"
-              echo "1. Settings → General → Allow auto-merge: ON"
-              echo "2. Settings → Branches: branch protection on \`$BASE_REF\` with a required status check"
+              echo "The PR is open and reviewable — a human needs to merge it for now."
+              echo
+              echo "### One-off admin setup to enable auto-merge for future PRs"
+              echo
+              echo "1. **Settings → General → Pull Requests → Allow auto-merge**: ON"
+              echo "2. **Settings → Branches**: branch protection on \`$BASE_REF\` with at least one required status check (e.g. \`CI / Pre-commit\`, \`CI / ROS Test\`)"
+              echo
+              echo "Both require **Admin** permission on this repo. Once an admin flips them, the next firmware-bump PR will auto-merge on green CI without any code changes."
               echo
               echo "### \`gh\` output"
+              echo
               echo "\`\`\`"
               cat "$OUT"
               echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+          # Exit 0 — the workflow run stays green (with a yellow warning
+          # annotation). The signal lives in the warning + Job Summary
+          # rather than a red failure, so we don't clutter the Actions
+          # tab with "broken" runs while the admin settings are pending.
           exit 0

--- a/rosbot/rosbot_hardware.repos
+++ b/rosbot/rosbot_hardware.repos
@@ -11,9 +11,13 @@ repositories:
     type: git
     url: https://github.com/micro-ROS/micro-ROS-Agent
     version: af007872b034d1ed31de4815377031350ab0034b
-  # Builds rosbot_mavlink_bridge (runtime dep of mavlink.launch.py).
-  # Flashing still uses bundled .bin in rosbot_utils/firmware/.
-  # `version` is auto-bumped by rosbot-firmware's release workflow.
+  # Source mirror of the rosbot-firmware repo. The only ROS package inside
+  # the tree (`bridge/rosbot_mavlink_bridge`) is picked up by colcon and
+  # builds the bridge — runtime dependency of mavlink.launch.py. Bundled
+  # .bin files in rosbot_utils/firmware/ stay the source of truth for
+  # flashing; this entry is for getting bridge + firmware sources into
+  # the workspace. `version` is auto-bumped by rosbot-firmware's release
+  # workflow.
   rosbot-firmware:
     type: git
     url: https://github.com/husarion/rosbot-firmware.git


### PR DESCRIPTION
## Summary

Add `unlabeled` to the `firmware-bump-automerge.yaml` event types so removing `block-automerge` (after a human finishes the manual edits on a breaking-change firmware bump PR) re-fires the job and enables auto-merge for the remainder of the CI cycle. Without it, removing the label was a silent no-op and the PR would still need manual merging.

Pairs with [husarion/rosbot-firmware@bf89691](https://github.com/husarion/rosbot-firmware/commit/bf89691), which automatically attaches `block-automerge` on `bump_type=major` firmware releases.

## Behaviour after the change

| Firmware bump | Labels on opened PR | Auto-merge | Removing `block-automerge` |
|---|---|---|---|
| patch / minor | `auto-firmware-bump` | armed on open | n/a |
| **major (breaking)** | `auto-firmware-bump` + `block-automerge` | NOT armed | re-fires workflow → arms auto-merge |

## Test plan

- [ ] Workflow file YAML parses (covered by `check-yaml` pre-commit hook)
- [ ] Manual smoke test next time a real firmware-bump PR opens — verify removing `block-automerge` arms auto-merge on the existing PR