### PR TITLE
Add contract test for C++ led_strip nodes

### DIFF
--- a/rosbot_utils/CMakeLists.txt
+++ b/rosbot_utils/CMakeLists.txt
@@ -29,6 +29,17 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(test_firmware_version test/test_firmware_version.py)
   ament_add_pytest_test(test_configs test/test_configs.py)
+
+  # test_led_strip launches the C++ animation nodes and subscribes to led_strip,
+  # so it needs an isolated, localhost-only DDS domain to stay reliable on CI.
+  ament_add_pytest_test(
+    test_led_strip
+    test/test_led_strip.py
+    ENV
+    ROS_DOMAIN_ID=87
+    ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST
+    TIMEOUT
+    120)
 endif()
 
 ament_package()

--- a/rosbot_utils/package.xml
+++ b/rosbot_utils/package.xml
@@ -33,8 +33,13 @@
   <exec_depend>usbutils</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_pytest</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>python3-yaml</test_depend>
+  <test_depend>rclpy</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosbot_utils/test/test_led_strip.py
+++ b/rosbot_utils/test/test_led_strip.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Husarion sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract guard for the C++ led_strip animation nodes.
+
+Both ``led_strip_car_wave`` and ``led_strip_rainbow`` must publish a 1x18 ``rgb8``
+``Image`` on ``led_strip`` over a BEST_EFFORT publisher. That shape + topic is the
+contract consumed downstream (rosbot_xl.yaml ``exec:`` entry -> LED bridge); the
+C++ migration must not drift from it.
+"""
+
+import time
+
+import launch_pytest
+import pytest
+import rclpy
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch_testing.actions import ReadyToTest
+from rclpy.qos import QoSProfile, QoSReliabilityPolicy
+from sensor_msgs.msg import Image
+
+NUM_LEDS = 18
+LED_EXECUTABLES = ["led_strip_car_wave", "led_strip_rainbow"]
+
+
+@launch_pytest.fixture
+def generate_test_description(request):
+    executable = request.param
+    led_node = Node(package="rosbot_utils", executable=executable, output="screen")
+    return LaunchDescription([led_node, ReadyToTest()]), executable
+
+
+@pytest.mark.parametrize("generate_test_description", LED_EXECUTABLES, indirect=True)
+@pytest.mark.launch(fixture=generate_test_description)
+def test_led_strip_image_contract(generate_test_description):
+    _, executable = generate_test_description
+
+    rclpy.init()
+    try:
+        node = rclpy.create_node("test_led_strip_sub")
+        # Publisher is BEST_EFFORT; a RELIABLE subscriber would be QoS-incompatible
+        # and receive nothing.
+        qos = QoSProfile(depth=1, reliability=QoSReliabilityPolicy.BEST_EFFORT)
+        received = []
+        node.create_subscription(Image, "led_strip", received.append, qos)
+
+        deadline = time.time() + 15.0
+        while time.time() < deadline and not received:
+            rclpy.spin_once(node, timeout_sec=0.1)
+
+        assert received, f"{executable}: no Image on 'led_strip' within timeout"
+
+        msg = received[0]
+        assert msg.height == 1, f"{executable}: height {msg.height} != 1"
+        assert msg.width == NUM_LEDS, f"{executable}: width {msg.width} != {NUM_LEDS}"
+        assert msg.encoding == "rgb8", f"{executable}: encoding {msg.encoding!r} != 'rgb8'"
+        assert not msg.is_bigendian, f"{executable}: is_bigendian should be False"
+        assert msg.step == NUM_LEDS * 3, f"{executable}: step {msg.step} != {NUM_LEDS * 3}"
+        assert (
+            len(msg.data) == NUM_LEDS * 3
+        ), f"{executable}: data len {len(msg.data)} != {NUM_LEDS * 3}"
+
+        node.destroy_node()
+    finally:
+        rclpy.shutdown()


### PR DESCRIPTION
## Changelog description

- Add `test_led_strip` (launch_pytest) covering the C++ `led_strip_car_wave` and `led_strip_rainbow` nodes migrated in #181. It launches each executable and asserts the published `Image` stays 1×18 `rgb8` (step 54) on the `led_strip` topic over a BEST_EFFORT publisher — the shape consumed downstream by the LED bridge (`rosbot_xl.yaml` `exec:` entry). Runs in an isolated localhost-only DDS domain.

Validation: `colcon test --packages-select rosbot_utils` — 2/2 led_strip cases pass, full package 0 failures.