### PR TITLE
Exit non-zero when firmware flashing fails

### DIFF
--- a/rosbot_utils/scripts/flash_firmware
+++ b/rosbot_utils/scripts/flash_firmware
@@ -99,6 +99,7 @@ def main(args=None):
         print("Firmware flashing completed successfully!")
     except Exception as e:
         print(f"ERROR: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `except` block printed `ERROR:` but didn't exit non-zero, so a failed flash exited 0. Callers keying off the exit code (e.g. the rosbot snap auto-flash gate) recorded success after a failure. Added `sys.exit(1)`.