### PR TITLE
Adopt custom component: bump dep + link docs in configs

### DIFF
--- a/justfile
+++ b/justfile
@@ -86,6 +86,9 @@ sim model='rosbot_xl': (build "rosbot_gazebo")
     set -eo pipefail; \
     source /opt/ros/jazzy/setup.bash; \
     source {{ws}}/install/setup.bash; \
+    if [ -e /usr/share/glvnd/egl_vendor.d/10_nvidia.json ] && command -v nvidia-smi >/dev/null 2>&1; then \
+      export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/10_nvidia.json; \
+    fi; \
     exec ros2 launch rosbot_gazebo simulation.yaml robot_model:={{model}}
 
 # Wipe build + install artefacts for a single package.

--- a/rosbot/rosbot_hardware.repos
+++ b/rosbot/rosbot_hardware.repos
@@ -2,7 +2,7 @@ repositories:
   husarion_components_description:
     type: git
     url: https://github.com/husarion/husarion_components_description.git
-    version: 5b92d1ce55d6503896e0a59ac910358c7e516d93
+    version: 5fa662cb735266fbdb6814e512d1da7aa39a58b9
   husarion_controllers:
     type: git
     url: https://github.com/husarion/husarion_controllers

--- a/rosbot/rosbot_simulation.repos
+++ b/rosbot/rosbot_simulation.repos
@@ -2,7 +2,7 @@ repositories:
   husarion_components_description:
     type: git
     url: https://github.com/husarion/husarion_components_description.git
-    version: 5b92d1ce55d6503896e0a59ac910358c7e516d93
+    version: 5fa662cb735266fbdb6814e512d1da7aa39a58b9
   husarion_controllers:
     type: git
     url: https://github.com/husarion/husarion_controllers

--- a/rosbot_description/config/rosbot/basic.yaml
+++ b/rosbot_description/config/rosbot/basic.yaml
@@ -1,4 +1,5 @@
 ---
+# Custom components (own URDF + mesh): https://github.com/husarion/husarion_components_description#custom-component
 components:
   - type: LDR02
     parent_link: cover_link

--- a/rosbot_description/config/rosbot/custom.yaml
+++ b/rosbot_description/config/rosbot/custom.yaml
@@ -1,2 +1,3 @@
 ---
+# Custom components (own URDF + mesh): https://github.com/husarion/husarion_components_description#custom-component
 components: []

--- a/rosbot_description/config/rosbot_xl/autonomy.yaml
+++ b/rosbot_description/config/rosbot_xl/autonomy.yaml
@@ -1,4 +1,5 @@
 ---
+# Custom components (own URDF + mesh): https://github.com/husarion/husarion_components_description#custom-component
 components:
   - type: LDR06
     parent_link: cover_link

--- a/rosbot_description/config/rosbot_xl/basic.yaml
+++ b/rosbot_description/config/rosbot_xl/basic.yaml
@@ -1,2 +1,3 @@
 ---
+# Custom components (own URDF + mesh): https://github.com/husarion/husarion_components_description#custom-component
 components: []

--- a/rosbot_description/config/rosbot_xl/custom.yaml
+++ b/rosbot_description/config/rosbot_xl/custom.yaml
@@ -1,2 +1,3 @@
 ---
+# Custom components (own URDF + mesh): https://github.com/husarion/husarion_components_description#custom-component
 components: []

--- a/rosbot_description/config/rosbot_xl/manipulation.yaml
+++ b/rosbot_description/config/rosbot_xl/manipulation.yaml
@@ -1,4 +1,5 @@
 ---
+# Custom components (own URDF + mesh): https://github.com/husarion/husarion_components_description#custom-component
 components:
   - type: LDR06
     parent_link: cover_link

--- a/rosbot_description/config/rosbot_xl/manipulation_pro.yaml
+++ b/rosbot_description/config/rosbot_xl/manipulation_pro.yaml
@@ -1,4 +1,5 @@
 ---
+# Custom components (own URDF + mesh): https://github.com/husarion/husarion_components_description#custom-component
 components:
   - type: LDR06
     parent_link: cover_link

--- a/rosbot_description/config/rosbot_xl/telepresence.yaml
+++ b/rosbot_description/config/rosbot_xl/telepresence.yaml
@@ -1,4 +1,5 @@
 ---
+# Custom components (own URDF + mesh): https://github.com/husarion/husarion_components_description#custom-component
 components:
   - type: CAM11
     parent_link: camera_mount_link


### PR DESCRIPTION
## Changelog description

Adopts the new `type: custom` component (husarion/husarion_components_description#21, now on `ros2`):

- Bump `husarion_components_description` pin to the custom-component merge in both `rosbot_hardware.repos` and `rosbot_simulation.repos`.
- Add a one-line link to the custom-component docs in every `rosbot_description` config (rosbot + rosbot_xl).
- `just sim`: force the NVIDIA EGL vendor (when an NVIDIA GPU is present) so Gazebo stops spamming Mesa `failed to create dri2 screen` warnings.

No behaviour change to the robot - configs still ship unchanged component lists; the link just points users at how to add their own URDF/mesh.